### PR TITLE
Make some Python API methods compatible with coming Mixer API changes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ The Python Client API currently supports `python>=3.6`. We use
 bazel then run the following:
 
 ```
-$ bazel build //...
-$ bazel test //...
+$ bazel build //... --incompatible_disable_deprecated_attr_params=false
+$ bazel test //... --incompatible_disable_deprecated_attr_params=false
 ```
 
 ## Support


### PR DESCRIPTION
We are going to change the places-in, population, and observation mixer API methods
so that they return maps from dcid to lists of dcids, population dcids, and
observation values respectively. Update the corresponding Python API methods so
that they work with both the new and old Mixer API versions.