### PR TITLE
fix unsorted series for get_stat_series

### DIFF
--- a/datacommons_pandas/df_builder.py
+++ b/datacommons_pandas/df_builder.py
@@ -46,7 +46,7 @@ def build_time_series(place,
       scaling_factor (`int`): Optional, the preferred `scalingFactor` value.
     Returns:
       A pandas Series with Place IDs as the index and observed statistics as
-      values, representing a time series satisfying all optional args.
+      values, representing a sorted time series satisfying all optional args.
     """
     return pd.Series(
         dc.get_stat_series(place, stat_var, measurement_method,

--- a/datacommons_pandas/df_builder.py
+++ b/datacommons_pandas/df_builder.py
@@ -50,7 +50,7 @@ def build_time_series(place,
     """
     return pd.Series(
         dc.get_stat_series(place, stat_var, measurement_method,
-                           observation_period, unit, scaling_factor))
+                           observation_period, unit, scaling_factor)).sort_index()
 
 
 def _group_stat_all_by_obs_options(places, stat_vars, keep_series=True):


### PR DESCRIPTION
fix the issue raised in #150 

Issue raised: series should be sorted

### Changes
changes in file: datacommons_pandas/df_builder.py 
changes in line: L49, L53

Change Description:
changed the return statement of function build_time_series  by adding a suffixing .sort_index()
also changed the docstring last line from " representing a time series satisfying all optional args." to "representing a sorted time series satisfying all optional args."

### Test Result
platform darwin -- Python 3.7.10, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
rootdir: /Users/manojbalaji/personal/api-python
collected 45 items                                                                                                                                                                                                                           

datacommons/test/core_test.py ...........                                                                                                                                                                                              [ 24%]
datacommons/test/places_test.py .........                                                                                                                                                                                              [ 44%]
datacommons/test/populations_test.py ........                                                                                                                                                                                          [ 62%]
datacommons/test/query_test.py ..                                                                                                                                                                                                      [ 66%]
datacommons/test/set_api_key_test.py ....                                                                                                                                                                                              [ 75%]
datacommons/test/stat_vars_test.py ......                                                                                                                                                                                              [ 88%]
datacommons_pandas/test/df_builder_test.py .....                                                                                                                                                                                       [100%]

Note: Not tested for Python2 since its deprecated 

