### PR TITLE
Remove broken symlink

### DIFF
--- a/datacommons_pandas/populations.py
+++ b/datacommons_pandas/populations.py
@@ -1,1 +1,0 @@
-../datacommons/populations.py


### PR DESCRIPTION
Closes #179 

The command that was broken was `gcloud meta list-files-for-upload` at the root of the repo. I verified that this is the only broken symlink in the repo by running the command after the change. As expected, no errors were raised. 