### PR TITLE
Implement Data Classes to Model API Responses

### DIFF
--- a/datacommons_client/models/node.py
+++ b/datacommons_client/models/node.py
@@ -1,0 +1,113 @@
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, TypeAlias
+
+NextToken: TypeAlias = Optional[str]
+NodeDCID: TypeAlias = str
+ArcLabel: TypeAlias = str
+Property: TypeAlias = str
+PropertyList: TypeAlias = list[Property]
+
+
+@dataclass
+class Node:
+    """Represents an individual node in the Data Commons knowledge graph.
+
+    Attributes:
+        dcid: The unique identifier for the node.
+        name: The name of the node.
+        provenanceId: The provenance ID for the node.
+        types: The types associated with the node.
+        value: The value of the node.
+    """
+
+    dcid: str = None
+    name: Optional[str] = None
+    provenanceId: Optional[str] = None
+    types: Optional[list[str]] = None
+    value: Optional[str] = None
+
+    @classmethod
+    def from_json(cls, json_data: Dict[str, Any]) -> "Node":
+        return cls(
+            dcid=json_data.get("dcid"),
+            name=json_data.get("name"),
+            provenanceId=json_data.get("provenanceId"),
+            types=json_data.get("types"),
+            value=json_data.get("value"),
+        )
+
+
+@dataclass
+class NodeGroup:
+    """Represents a group of nodes in the Data Commons knowledge graph.
+
+    Attributes:
+        nodes: A list of Node objects in the group.
+    """
+
+    nodes: List[Node] = field(default_factory=list)
+
+    @classmethod
+    def from_json(cls, json_data: Dict[str, Any]) -> "NodeGroup":
+        """Parses a dictionary of lists of nodes from the response data.
+
+        Args:
+            json_data: The raw JSON data containing node information.
+
+        Returns:
+            A NodeGroup instance.
+        """
+        return cls(
+            nodes=[Node.from_json(node) for node in json_data.get("nodes", [])]
+        )
+
+
+@dataclass
+class Arcs:
+    """Represents arcs in the Data Commons knowledge graph.
+
+    Attributes:
+        arcs: A dictionary mapping arc labels to NodeGroup objects.
+    """
+
+    arcs: Dict[ArcLabel, NodeGroup] = field(default_factory=dict)
+
+    @classmethod
+    def from_json(cls, json_data: Dict[str, Any]) -> "Arcs":
+        """Parses a dictionary of arcs from JSON.
+
+        Args:
+            json_data: The raw JSON data containing arc information.
+
+        Returns:
+            An Arcs instance.
+        """
+        return cls(
+            arcs={
+                label: NodeGroup.from_json(nodes)
+                for label, nodes in json_data.items()
+            }
+        )
+
+
+@dataclass
+class Properties:
+    """Represents a group of properties in the Data Commons knowledge graph.
+
+    Attributes:
+        properties: A list of property strings.
+    """
+
+    properties: List[Property] = field(default_factory=PropertyList)
+
+    @classmethod
+    def from_json(cls, json_data: Dict[str, Any]) -> "Properties":
+        """Parses a list of properties from JSON.
+
+        Args:
+            json_data: The raw JSON data containing property information.
+
+        Returns:
+            A Properties instance.
+        """
+        return cls(properties=json_data.get("properties", []))

--- a/datacommons_client/models/observation.py
+++ b/datacommons_client/models/observation.py
@@ -1,0 +1,147 @@
+from dataclasses import dataclass, field
+from typing import Any, Dict, TypeAlias
+
+variableDCID: TypeAlias = str
+facetID: TypeAlias = str
+
+orderedFacetsLabel: TypeAlias = str
+
+
+@dataclass
+class Observation:
+    """Represents an observation with a date and value.
+
+    Attributes:
+        date (str): The date of the observation.
+        value (float): The value of the observation.
+    """
+
+    date: str
+    value: float
+
+    @classmethod
+    def from_json(cls, json_data: Dict[str, Any]) -> "Observation":
+        """Creates an Observation instance from the response data.
+
+        Args:
+            json_data: A dictionary containing observation data.
+
+        Returns:
+            An Observation instance.
+        """
+        return cls(
+            date=json_data.get("date"),
+            value=json_data.get("value"),
+        )
+
+
+@dataclass
+class OrderedFacets:
+    """Represents ordered facets of observations.
+
+    Attributes:
+        earliestDate (str): The earliest date in the observations.
+        facetId (str): The identifier for the facet.
+        latestDate (str): The latest date in the observations.
+        obsCount (int): The total number of observations.
+        observations (List[Observation]): A list of observations associated with the facet.
+    """
+
+    earliestDate: str = field(default_factory=str)
+    facetId: str = field(default_factory=str)
+    latestDate: str = field(default_factory=str)
+    obsCount: int = field(default_factory=int)
+    observations: list[Observation] = field(default_factory=list)
+
+    @classmethod
+    def from_json(cls, json_data: Dict[str, Any]) -> "OrderedFacets":
+        """Creates an OrderedFacets instance from the response data.
+
+        Args:
+            json_data (Dict[str, Any]): A dictionary containing ordered facets data.
+
+        Returns:
+            OrderedFacets: An instance of the OrderedFacets class.
+        """
+        return cls(
+            earliestDate=json_data.get("earliestDate"),
+            facetId=json_data.get("facetId"),
+            latestDate=json_data.get("latestDate"),
+            obsCount=json_data.get("obsCount"),
+            observations=[
+                Observation.from_json(observation)
+                for observation in json_data.get("observations", [])
+            ],
+        )
+
+
+@dataclass
+class Variable:
+    """Represents a variable with data grouped by entity.
+
+    Attributes:
+        byEntity (Dict[str, Dict[orderedFacetsLabel, List[OrderedFacets]]]): A dictionary mapping
+            entities to their ordered facets.
+    """
+
+    byEntity: Dict[str, Dict[orderedFacetsLabel, list[OrderedFacets]]] = field(
+        default_factory=dict
+    )
+
+    @classmethod
+    def from_json(cls, json_data: Dict[str, Any]) -> "Variable":
+        """Creates a Variable instance from the response data.
+
+        Args:
+            json_data (Dict[str, Any]): A dictionary containing variable data.
+
+        Returns:
+            Variable: An instance of the Variable class.
+        """
+        return cls(
+            byEntity={
+                entity: {
+                    "orderedFacets": [
+                        OrderedFacets.from_json(facet_data)
+                        for facet_data in entity_data["orderedFacets"]
+                    ]
+                }
+                for entity, entity_data in json_data["byEntity"].items()
+            }
+        )
+
+
+@dataclass
+class Facet:
+    """Represents metadata for a facet.
+
+    Attributes:
+        importName (str): The name of the data import.
+        measurementMethod (str): The method used to measure the data.
+        observationPeriod (str): The period over which the observations were made.
+        provenanceUrl (str): The URL of the data's provenance.
+        unit (str): The unit of the observations.
+    """
+
+    importName: str = field(default_factory=str)
+    measurementMethod: str = field(default_factory=str)
+    observationPeriod: str = field(default_factory=str)
+    provenanceUrl: str = field(default_factory=str)
+    unit: str = field(default_factory=str)
+
+    @classmethod
+    def from_json(cls, json_data: Dict[str, Any]) -> "Facet":
+        """
+        Args:
+            json_data (Dict[str, Any]): A dictionary containing facet data.
+
+        Returns:
+            Facet: An instance of the Facet class.
+        """
+        return cls(
+            importName=json_data.get("importName"),
+            measurementMethod=json_data.get("measurementMethod"),
+            observationPeriod=json_data.get("observationPeriod"),
+            provenanceUrl=json_data.get("provenanceUrl"),
+            unit=json_data.get("unit"),
+        )

--- a/datacommons_client/models/resolve.py
+++ b/datacommons_client/models/resolve.py
@@ -1,0 +1,69 @@
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, TypeAlias
+
+Query: TypeAlias = str
+DCID: TypeAlias = str
+DominantType: TypeAlias = str
+
+
+@dataclass
+class Candidate:
+    """Represents a candidate in the resolution response.
+
+    Attributes:
+        dcid (DCID): The Data Commons ID for the candidate.
+        dominantType (Optional[DominantType]): The dominant type of the candidate,
+            if available. This represents the primary type associated with the DCID.
+    """
+
+    dcid: DCID = field(default_factory=str)
+    dominantType: Optional[DominantType] = None
+
+    @classmethod
+    def from_json(cls, json_data: Dict[str, Any]) -> "Candidate":
+        """Parses a Candidate instance from the response data.
+
+        Args:
+            json_data (Dict[str, Any]): A dictionary containing candidate data,
+                typically from the Data Commons API.
+
+        Returns:
+            Candidate: An instance of the Candidate class populated with the
+            provided data.
+        """
+        return cls(
+            dcid=json_data["dcid"],
+            dominantType=json_data.get("dominantType"),
+        )
+
+
+@dataclass
+class Entity:
+    """Represents an entity with its resolution candidates.
+
+    Attributes:
+        node (Query): The query string or node being resolved.
+        candidates (List[Candidate]): A list of candidates that match the query.
+    """
+
+    node: Query
+    candidates: List[Candidate] = field(default_factory=list)
+
+    @classmethod
+    def from_json(cls, json_data: Dict[str, Any]) -> "Entity":
+        """Parses an Entity instance from response data.
+
+        Args:
+            json_data (Dict[str, Any]): A dictionary containing entity data,
+                including the node and associated candidates.
+
+        Returns:
+            Entity: A populated instance of the Entity class.
+        """
+        return cls(
+            node=json_data.get("node"),
+            candidates=[
+                Candidate.from_json(candidate)
+                for candidate in json_data.get("candidates", [])
+            ],
+        )

--- a/datacommons_client/models/sparql.py
+++ b/datacommons_client/models/sparql.py
@@ -1,0 +1,47 @@
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+
+@dataclass
+class Cell:
+    """Represents a single cell in a row.
+
+    Attributes:
+        value: The value contained in the cell.
+    """
+
+    value: str = field(default_factory=str)
+
+    @classmethod
+    def from_json(cls, json_data: Dict[str, Any]) -> "Cell":
+        """Parses a Cell instance from response data.
+
+        Args:
+            json_data (Dict[str, Any]): A dictionary containing cell data.
+
+        Returns:
+            Cell: A populated instance of the Cell class.
+        """
+
+        return cls(value=json_data.get("value"))
+
+
+@dataclass
+class Row:
+    """Parses a Row instance from response data.
+
+    Args:
+        json_data (Dict[str, Any]): A dictionary containing row data,
+            typically with a "cells" key containing a list of cells.
+
+    Returns:
+        Row: A populated instance of the Row class.
+    """
+
+    cells: List[Cell] = field(default_factory=list)
+
+    @classmethod
+    def from_json(cls, json_data: Dict[str, Any]) -> "Row":
+        return cls(
+            cells=[Cell.from_json(cell) for cell in json_data.get("cells", [])]
+        )

--- a/datacommons_client/tests/models/test_node_models.py
+++ b/datacommons_client/tests/models/test_node_models.py
@@ -1,0 +1,89 @@
+from datacommons_client.models.node import Arcs, Node, NodeGroup, Properties
+
+
+def test_node_from_json():
+    """Test the Node.from_json method."""
+    json_data = {
+        "dcid": "node123",
+        "name": "Test Node",
+        "provenanceId": "prov123",
+        "types": ["TypeA", "TypeB"],
+        "value": "42",
+    }
+    node = Node.from_json(json_data)
+    assert node.dcid == "node123"
+    assert node.name == "Test Node"
+    assert node.provenanceId == "prov123"
+    assert node.types == ["TypeA", "TypeB"]
+    assert node.value == "42"
+
+
+def test_node_from_json_partial():
+    """Test Node.from_json with partial data."""
+    json_data = {
+        "dcid": "node123",
+    }
+    node = Node.from_json(json_data)
+    assert node.dcid == "node123"
+    assert node.name is None
+    assert node.provenanceId is None
+    assert node.types is None
+    assert node.value is None
+
+
+def test_nodegroup_from_json():
+    """Test the NodeGroup.from_json method."""
+    json_data = {
+        "nodes": [
+            {"dcid": "node1", "name": "Node 1"},
+            {"dcid": "node2", "name": "Node 2"},
+        ]
+    }
+    node_group = NodeGroup.from_json(json_data)
+    assert len(node_group.nodes) == 2
+    assert node_group.nodes[0].dcid == "node1"
+    assert node_group.nodes[1].name == "Node 2"
+
+
+def test_nodegroup_from_json_empty():
+    """Test NodeGroup.from_json with empty data."""
+    json_data = {}
+    node_group = NodeGroup.from_json(json_data)
+    assert len(node_group.nodes) == 0
+
+
+def test_arcs_from_json():
+    """Test the Arcs.from_json method."""
+    json_data = {
+        "label1": {"nodes": [{"dcid": "node1"}, {"dcid": "node2"}]},
+        "label2": {"nodes": [{"dcid": "node3"}]},
+    }
+    arcs = Arcs.from_json(json_data)
+    assert len(arcs.arcs) == 2
+    assert "label1" in arcs.arcs
+    assert len(arcs.arcs["label1"].nodes) == 2
+    assert arcs.arcs["label1"].nodes[0].dcid == "node1"
+    assert len(arcs.arcs["label2"].nodes) == 1
+    assert arcs.arcs["label2"].nodes[0].dcid == "node3"
+
+
+def test_arcs_from_json_empty():
+    """Test Arcs.from_json with empty data."""
+    json_data = {}
+    arcs = Arcs.from_json(json_data)
+    assert len(arcs.arcs) == 0
+
+
+def test_properties_from_json():
+    """Test the Properties.from_json method."""
+    json_data = {"properties": ["prop1", "prop2", "prop3"]}
+    properties = Properties.from_json(json_data)
+    assert len(properties.properties) == 3
+    assert properties.properties == ["prop1", "prop2", "prop3"]
+
+
+def test_properties_from_json_empty():
+    """Test Properties.from_json with empty data."""
+    json_data = {}
+    properties = Properties.from_json(json_data)
+    assert len(properties.properties) == 0

--- a/datacommons_client/tests/models/test_observation_models.py
+++ b/datacommons_client/tests/models/test_observation_models.py
@@ -1,0 +1,119 @@
+from datacommons_client.models.observation import (
+    Facet,
+    Observation,
+    OrderedFacets,
+    Variable,
+)
+
+
+def test_observation_from_json():
+    """Test the Observation.from_json method."""
+    json_data = {"date": "2024-01-01", "value": 123.45}
+    observation = Observation.from_json(json_data)
+    assert observation.date == "2024-01-01"
+    assert observation.value == 123.45
+    assert isinstance(observation.value, float)
+
+
+def test_observation_from_json_partial():
+    """Test Observation.from_json with missing data."""
+    json_data = {"date": "2024-01-01"}
+    observation = Observation.from_json(json_data)
+    assert observation.date == "2024-01-01"
+    assert observation.value is None
+
+
+def test_ordered_facets_from_json():
+    """Test the OrderedFacets.from_json method."""
+    json_data = {
+        "earliestDate": "2023-01-01",
+        "facetId": "facet123",
+        "latestDate": "2024-01-01",
+        "obsCount": 2,
+        "observations": [
+            {"date": "2023-01-01", "value": 100.0},
+            {"date": "2024-01-01", "value": 200.0},
+        ],
+    }
+    ordered_facets = OrderedFacets.from_json(json_data)
+    assert ordered_facets.earliestDate == "2023-01-01"
+    assert ordered_facets.facetId == "facet123"
+    assert ordered_facets.latestDate == "2024-01-01"
+    assert ordered_facets.obsCount == 2
+    assert len(ordered_facets.observations) == 2
+    assert ordered_facets.observations[0].value == 100.0
+
+
+def test_ordered_facets_from_json_empty_observations():
+    """Test OrderedFacets.from_json with empty observations."""
+    json_data = {
+        "earliestDate": "2023-01-01",
+        "facetId": "facet123",
+        "latestDate": "2024-01-01",
+        "obsCount": 0,
+        "observations": [],
+    }
+    ordered_facets = OrderedFacets.from_json(json_data)
+    assert len(ordered_facets.observations) == 0
+
+
+def test_variable_from_json():
+    """Test the Variable.from_json method."""
+    json_data = {
+        "byEntity": {
+            "entity1": {
+                "orderedFacets": [
+                    {
+                        "earliestDate": "2023-01-01",
+                        "facetId": "facet1",
+                        "latestDate": "2023-12-31",
+                        "obsCount": 2,
+                        "observations": [
+                            {"date": "2023-01-01", "value": 50.0},
+                            {"date": "2023-12-31", "value": 75.0},
+                        ],
+                    }
+                ]
+            }
+        }
+    }
+    variable = Variable.from_json(json_data)
+    assert "entity1" in variable.byEntity
+    facets = variable.byEntity["entity1"]["orderedFacets"]
+    assert len(facets) == 1
+    assert facets[0].facetId == "facet1"
+    assert facets[0].observations[0].value == 50.0
+
+
+def test_variable_from_json_empty():
+    """Test Variable.from_json with empty byEntity."""
+    json_data = {"byEntity": {}}
+    variable = Variable.from_json(json_data)
+    assert len(variable.byEntity) == 0
+
+
+def test_facet_from_json():
+    """Test the Facet.from_json method."""
+    json_data = {
+        "importName": "Import 1",
+        "measurementMethod": "Method A",
+        "observationPeriod": "2023",
+        "provenanceUrl": "http://example.com",
+        "unit": "usd",
+    }
+    facet = Facet.from_json(json_data)
+    assert facet.importName == "Import 1"
+    assert facet.measurementMethod == "Method A"
+    assert facet.observationPeriod == "2023"
+    assert facet.provenanceUrl == "http://example.com"
+    assert facet.unit == "usd"
+
+
+def test_facet_from_json_partial():
+    """Test Facet.from_json with missing data."""
+    json_data = {"importName": "Import 1", "unit": "GTQ"}
+    facet = Facet.from_json(json_data)
+    assert facet.importName == "Import 1"
+    assert facet.measurementMethod is None
+    assert facet.unit == "GTQ"
+    assert facet.provenanceUrl is None

--- a/datacommons_client/tests/models/test_resolve_models.py
+++ b/datacommons_client/tests/models/test_resolve_models.py
@@ -1,0 +1,61 @@
+from datacommons_client.models.resolve import Candidate, Entity
+
+
+def test_candidate_from_json():
+    """Test the Candidate.from_json method with full data."""
+    json_data = {"dcid": "dcid123", "dominantType": "Place"}
+    candidate = Candidate.from_json(json_data)
+    assert candidate.dcid == "dcid123"
+    assert candidate.dominantType == "Place"
+
+
+def test_candidate_from_json_partial():
+    """Test Candidate.from_json with missing optional dominantType."""
+    json_data = {"dcid": "dcid456"}
+    candidate = Candidate.from_json(json_data)
+    assert candidate.dcid == "dcid456"
+    assert candidate.dominantType is None
+
+
+def test_entity_from_json():
+    """Test the Entity.from_json method with multiple candidates."""
+    json_data = {
+        "node": "test_query",
+        "candidates": [
+            {"dcid": "dcid123", "dominantType": "Place"},
+            {"dcid": "dcid456", "dominantType": "Event"},
+        ],
+    }
+    entity = Entity.from_json(json_data)
+    assert entity.node == "test_query"
+    assert len(entity.candidates) == 2
+    assert entity.candidates[0].dcid == "dcid123"
+    assert entity.candidates[0].dominantType == "Place"
+    assert entity.candidates[1].dcid == "dcid456"
+    assert entity.candidates[1].dominantType == "Event"
+
+
+def test_entity_from_json_empty_candidates():
+    """Test Entity.from_json with no candidates."""
+    json_data = {"node": "test_query", "candidates": []}
+    entity = Entity.from_json(json_data)
+    assert entity.node == "test_query"
+    assert len(entity.candidates) == 0
+
+
+def test_entity_from_json_missing_node():
+    """Test Entity.from_json with missing node."""
+    json_data = {"candidates": [{"dcid": "dcid123", "dominantType": "Place"}]}
+    entity = Entity.from_json(json_data)
+    assert entity.node is None
+    assert len(entity.candidates) == 1
+    assert entity.candidates[0].dcid == "dcid123"
+    assert entity.candidates[0].dominantType == "Place"
+
+
+def test_entity_from_json_empty():
+    """Test Entity.from_json with empty data."""
+    json_data = {}
+    entity = Entity.from_json(json_data)
+    assert entity.node is None
+    assert len(entity.candidates) == 0

--- a/datacommons_client/tests/models/test_sparql_models.py
+++ b/datacommons_client/tests/models/test_sparql_models.py
@@ -1,0 +1,66 @@
+from datacommons_client.models.sparql import Cell, Row
+
+
+def test_cell_from_json():
+    """Test the Cell.from_json method with valid data."""
+    json_data = {"value": "Test Value"}
+    cell = Cell.from_json(json_data)
+    assert cell.value == "Test Value"
+
+
+def test_cell_int_from_json():
+    """ "Test the Cell.from_json method with valid data (int)."""
+    json_data = {"value": 5}
+    cell = Cell.from_json(json_data)
+    assert cell.value == 5
+
+
+def test_cell_from_json_missing_value():
+    """Test Cell.from_json with missing value field."""
+    json_data = {}
+    cell = Cell.from_json(json_data)
+    assert cell.value is None
+
+
+def test_row_from_json():
+    """Test the Row.from_json method with multiple cells."""
+    json_data = {
+        "cells": [
+            {"value": "Cell 1"},
+            {"value": "Cell 2"},
+            {"value": "Cell 3"},
+        ]
+    }
+    row = Row.from_json(json_data)
+    assert len(row.cells) == 3
+    assert row.cells[0].value == "Cell 1"
+    assert row.cells[1].value == "Cell 2"
+    assert row.cells[2].value == "Cell 3"
+
+
+def test_row_from_json_empty_cells():
+    """Test Row.from_json with an empty list of cells."""
+    json_data = {"cells": []}
+    row = Row.from_json(json_data)
+    assert len(row.cells) == 0
+
+
+def test_row_from_json_missing_cells():
+    """Test Row.from_json with missing cells field."""
+    json_data = {}
+    row = Row.from_json(json_data)
+    assert len(row.cells) == 0
+
+
+def test_row_with_nested_empty_cells():
+    """Test Row.from_json with cells containing empty cell data."""
+    json_data = {
+        "cells": [
+            {},
+            {"value": "Cell 2"},
+        ]
+    }
+    row = Row.from_json(json_data)
+    assert len(row.cells) == 2
+    assert row.cells[0].value is None
+    assert row.cells[1].value == "Cell 2"


### PR DESCRIPTION
**Note:**
Previous PR in the stack: #202
Next PR in the stack #204

---
This PR implements dataclasses to model API responses from all endpoints. These data classes represent various entities in the Data Commons knowledge graph. Dan's comments on the design document provide more details about the rationale.

### Data Classes

* [`datacommons_client/models/node.py`](diffhunk://#diff-1816caba4b54e536065474e7e040883c0e23d27651b707995781b8458066fd9fR1-R113): Added `Node`, `NodeGroup`, `Arcs`, and `Properties` data classes to represent nodes, groups of nodes, arcs, and properties in the Data Commons knowledge graph. 

* [`datacommons_client/models/observation.py`](diffhunk://#diff-f1f665d269a5d622ebcb7cc1f5f3fdaaa7556e4a29f6523f3e33bede0e5136b5R1-R147): Added `Observation`, `OrderedFacets`, `Variable`, and `Facet` data classes to represent observations, ordered facets, variables, and facets in the Data Commons knowledge graph.

* [`datacommons_client/models/resolve.py`](diffhunk://#diff-0ed570a995621dfe4a5781d43a21fe506a1fe141c35268c778c482f95fcd7fadR1-R69): Added `Candidate` and `Entity` data classes to represent candidates and entities in the resolution response. 

* [`datacommons_client/models/sparql.py`](diffhunk://#diff-8335343c9816ac0358beff5d328035ebafd60faf90fbc6606804c595f92f23dcR1-R47): Added `Cell` and `Row` data classes to represent cells and rows in a SPARQL query response. Note that the sparql endpoint does not (currently) work for custom instances.

### Unit Tests
In general, the tests for these classes are just making sure that the objects (especially objects that incorporate other objects) are built consistently and correctly. We avoid testing any basic python functionality.

* [`datacommons_client/tests/models/test_node_models.py`](diffhunk://#diff-4058485f3c30d988e24c32c4ac8f517a5ad4348f5989a14f62bb6c2b70b1504bR1-R89): Added unit tests for the `Node`, `NodeGroup`, `Arcs`, and `Properties` classes, testing their `from_json` methods with both complete and partial data.

* [`datacommons_client/tests/models/test_observation_models.py`](diffhunk://#diff-87e57af360d22010c5c80b4dcf448f3073ddbe290b8a6c5bd263a6c4bea4185bR1-R119): Added unit tests for the `Observation`, `OrderedFacets`, `Variable`, and `Facet` classes, testing their `from_json` methods with various data scenarios.

* [`datacommons_client/tests/models/test_resolve_models.py`](diffhunk://#diff-cc8342bb5732876dfa7986e3ecaff30aa1fa8eb58f4b09c92ad81a8d5e3cb050R1-R61): Added unit tests for the `Candidate` and `Entity` classes, testing their `from_json` methods with complete, partial, and empty data.

* [`datacommons_client/tests/models/test_sparql_models.py`](diffhunk://#diff-19691f8cf390ab51d2c5f9963d97a94e406bf7596796440a037d1afe83a5684aR1-R66): Added unit tests for the `Cell` and `Row` classes, testing their `from_json` methods with different types of cell data, including nested empty cells.