### PR TITLE
Add client class

### DIFF
--- a/datacommons_client/client.py
+++ b/datacommons_client/client.py
@@ -8,13 +8,13 @@ from datacommons_client.endpoints.resolve import ResolveEndpoint
 from datacommons_client.utils.decorators import requires_pandas
 
 try:
-    import pandas as pd
+  import pandas as pd
 except ImportError:
-    pd = None
+  pd = None
 
 
 class DataCommonsClient:
-    """
+  """
     A client for interacting with the Data Commons API.
 
     This class provides convenient access to the V2 Data Commons API endpoints.
@@ -29,14 +29,14 @@ class DataCommonsClient:
 
     """
 
-    def __init__(
-        self,
-        api_key: Optional[str] = None,
-        *,
-        dc_instance: Optional[str] = "datacommons.org",
-        url: Optional[str] = None,
-    ):
-        """
+  def __init__(
+      self,
+      api_key: Optional[str] = None,
+      *,
+      dc_instance: Optional[str] = "datacommons.org",
+      url: Optional[str] = None,
+  ):
+    """
         Initializes the DataCommonsClient.
 
         Args:
@@ -45,24 +45,24 @@ class DataCommonsClient:
             dc_instance (Optional[str]): The Data Commons instance to use. Defaults to "datacommons.org".
             url (Optional[str]): A custom, fully resolved URL for the Data Commons API. Defaults to None.
         """
-        # Create an instance of the API class which will be injected to the endpoints
-        self.api = API(api_key=api_key, dc_instance=dc_instance, url=url)
+    # Create an instance of the API class which will be injected to the endpoints
+    self.api = API(api_key=api_key, dc_instance=dc_instance, url=url)
 
-        # Create instances of the endpoints
-        self.node = NodeEndpoint(api=self.api)
-        self.observation = ObservationEndpoint(api=self.api)
-        self.resolve = ResolveEndpoint(api=self.api)
+    # Create instances of the endpoints
+    self.node = NodeEndpoint(api=self.api)
+    self.observation = ObservationEndpoint(api=self.api)
+    self.resolve = ResolveEndpoint(api=self.api)
 
-    @requires_pandas
-    def observations_dataframe(
-        self,
-        variable_dcids: str | list[str],
-        date: ObservationDate | str,
-        entity_dcids: Literal["all"] | list[str] = "all",
-        entity_type: Optional[str] = None,
-        parent_entity: Optional[str] = None,
-    ):
-        """
+  @requires_pandas
+  def observations_dataframe(
+      self,
+      variable_dcids: str | list[str],
+      date: ObservationDate | str,
+      entity_dcids: Literal["all"] | list[str] = "all",
+      entity_type: Optional[str] = None,
+      parent_entity: Optional[str] = None,
+  ):
+    """
         Fetches statistical observations and returns them as a Pandas DataFrame.
 
         The Observation API fetches statistical observations linked to entities and variables
@@ -83,26 +83,24 @@ class DataCommonsClient:
             pd.DataFrame: A DataFrame containing the requested observations.
         """
 
-        if entity_dcids == "all" and not entity_type:
-            raise ValueError(
-                "When 'entity_dcids' is 'all', 'entity_type' must be specified."
-            )
+    if entity_dcids == "all" and not entity_type:
+      raise ValueError(
+          "When 'entity_dcids' is 'all', 'entity_type' must be specified.")
 
-        if entity_dcids != "all" and (entity_type or parent_entity):
-            raise ValueError(
-                "Specify 'entity_type' and 'parent_entity' only when 'entity_dcids' is 'all'."
-            )
+    if entity_dcids != "all" and (entity_type or parent_entity):
+      raise ValueError(
+          "Specify 'entity_type' and 'parent_entity' only when 'entity_dcids' is 'all'."
+      )
 
-        if entity_dcids == "all":
-            observations = self.observation.fetch_observations_by_entity_type(
-                variable_dcids=variable_dcids,
-                date=date,
-                entity_type=entity_type,
-                parent_entity=parent_entity,
-            )
-        else:
-            observations = self.observation.fetch_observations_by_entity(
-                variable_dcids=variable_dcids, date=date, entity_dcids=entity_dcids
-            )
+    if entity_dcids == "all":
+      observations = self.observation.fetch_observations_by_entity_type(
+          variable_dcids=variable_dcids,
+          date=date,
+          entity_type=entity_type,
+          parent_entity=parent_entity,
+      )
+    else:
+      observations = self.observation.fetch_observations_by_entity(
+          variable_dcids=variable_dcids, date=date, entity_dcids=entity_dcids)
 
-        return pd.DataFrame(observations.get_observations_as_records())
+    return pd.DataFrame(observations.get_observations_as_records())

--- a/datacommons_client/client.py
+++ b/datacommons_client/client.py
@@ -1,0 +1,108 @@
+from typing import Literal, Optional
+
+from datacommons_client.endpoints.base import API
+from datacommons_client.endpoints.node import NodeEndpoint
+from datacommons_client.endpoints.observation import ObservationEndpoint
+from datacommons_client.endpoints.payloads import ObservationDate
+from datacommons_client.endpoints.resolve import ResolveEndpoint
+from datacommons_client.utils.decorators import requires_pandas
+
+try:
+    import pandas as pd
+except ImportError:
+    pd = None
+
+
+class DataCommonsClient:
+    """
+    A client for interacting with the Data Commons API.
+
+    This class provides convenient access to the V2 Data Commons API endpoints.
+
+    Attributes:
+        api (API): An instance of the API class that handles requests.
+        node (NodeEndpoint): Provides access to node-related queries, such as fetching property labels
+            and values for individual or multiple nodes in the Data Commons knowledge graph.
+        observation (ObservationEndpoint): Handles observation-related queries, allowing retrieval of
+            statistical observations associated with entities, variables, and dates (e.g., GDP of California in 2010).
+        resolve (ResolveEndpoint): Manages resolution queries to find different DCIDs for entities.
+
+    """
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        *,
+        dc_instance: Optional[str] = "datacommons.org",
+        url: Optional[str] = None,
+    ):
+        """
+        Initializes the DataCommonsClient.
+
+        Args:
+            api_key (Optional[str]): The API key for authentication. Defaults to None. Note that
+                custom DC instances do not currently require an API key.
+            dc_instance (Optional[str]): The Data Commons instance to use. Defaults to "datacommons.org".
+            url (Optional[str]): A custom, fully resolved URL for the Data Commons API. Defaults to None.
+        """
+        # Create an instance of the API class which will be injected to the endpoints
+        self.api = API(api_key=api_key, dc_instance=dc_instance, url=url)
+
+        # Create instances of the endpoints
+        self.node = NodeEndpoint(api=self.api)
+        self.observation = ObservationEndpoint(api=self.api)
+        self.resolve = ResolveEndpoint(api=self.api)
+
+    @requires_pandas
+    def observations_dataframe(
+        self,
+        variable_dcids: str | list[str],
+        date: ObservationDate | str,
+        entity_dcids: Literal["all"] | list[str] = "all",
+        entity_type: Optional[str] = None,
+        parent_entity: Optional[str] = None,
+    ):
+        """
+        Fetches statistical observations and returns them as a Pandas DataFrame.
+
+        The Observation API fetches statistical observations linked to entities and variables
+        at a particular date (e.g., "population of USA in 2020", "GDP of California in 2010").
+
+        Args:
+            variable_dcids (str | list[str]): One or more variable DCIDs for the observation.
+            date (ObservationDate | str): The date for which observations are requested. It can be
+            a specific date, "all" to retrieve all observations, or "latest" to get the most recent observations.
+            entity_dcids (Literal["all"] | list[str], optional): The entity DCIDs to retrieve data for.
+                Defaults to "all". DCIDs must include their type (e.g "country/GTM" for Guatemala).
+            entity_type (Optional[str], optional): The type of entities to filter by when `entity_dcids="all"`.
+                Required if `entity_dcids="all"`. Defaults to None.
+            parent_entity (Optional[str], optional): The parent entity under which the target entities fall.
+                Used only when `entity_dcids="all"`. Defaults to None.
+
+        Returns:
+            pd.DataFrame: A DataFrame containing the requested observations.
+        """
+
+        if entity_dcids == "all" and not entity_type:
+            raise ValueError(
+                "When 'entity_dcids' is 'all', 'entity_type' must be specified."
+            )
+
+        if entity_dcids != "all" and (entity_type or parent_entity):
+            raise ValueError(
+                "Specify 'entity_type' and 'parent_entity' only when 'entity_dcids' is 'all'."
+            )
+
+        if entity_dcids == "all":
+            observations = self.observation.fetch_observations_by_entity_type(
+                variable_dcids=variable_dcids,
+                date=date,
+                entity_type=entity_type,
+                parent_entity=parent_entity,
+            )
+        else:
+            observations = self.observation.fetch_observations_by_entity(
+                variable_dcids=variable_dcids, date=date, entity_dcids=entity_dcids
+            )
+
+        return pd.DataFrame(observations.get_observations_as_records())

--- a/datacommons_client/endpoints/observation.py
+++ b/datacommons_client/endpoints/observation.py
@@ -104,7 +104,7 @@ class ObservationEndpoint(Endpoint):
       parent_entity: str,
       entity_type: str,
       variable_dcids: str | list[str],
-  ):
+  )-> ObservationResponse:
     """
         Fetches all observations for a given entity type.
 
@@ -149,7 +149,7 @@ class ObservationEndpoint(Endpoint):
       date: ObservationDate | str,
       entity_dcids: str | list[str],
       variable_dcids: str | list[str],
-  ):
+  )-> ObservationResponse:
     """
         Fetches all observations for a given entity type.
 

--- a/datacommons_client/endpoints/observation.py
+++ b/datacommons_client/endpoints/observation.py
@@ -143,3 +143,43 @@ class ObservationEndpoint(Endpoint):
         entity_expression=
         f"{parent_entity}<-containedInPlace+{{typeOf:{entity_type}}}",
     )
+
+  def fetch_observations_by_entity(
+      self,
+      date: ObservationDate | str,
+      entity_dcids: str | list[str],
+      variable_dcids: str | list[str],
+  ):
+    """
+        Fetches all observations for a given entity type.
+
+        Args:
+            date (ObservationDate | str): The date option for the observations.
+                Use 'all' for all dates, 'latest' for the most recent data,
+                or provide a date as a string (e.g., "2024").
+            entity_dcids (str | list[str]): One or more entity IDs to filter the data.
+            variable_dcids (str | list[str]): The variable(s) to fetch observations for.
+                This can be a single variable ID or a list of IDs.
+
+        Returns:
+            ObservationResponse: The response object containing observations for the specified entity type.
+
+        Example:
+            To fetch all observations for Nigeria for a specific variable:
+
+            ```python
+            api = API()
+            ObservationEndpoint(api).fetch_observations_by_entity(
+                date="all",
+                entity_dcids="country/NGA",
+                variable_dcids="sdg/SI_POV_DAY1"
+            )
+            ```
+        """
+
+    return self.fetch(
+        variable_dcids=variable_dcids,
+        date=date,
+        entity_dcids=entity_dcids,
+        select=[s for s in ObservationSelect],
+    )

--- a/datacommons_client/endpoints/observation.py
+++ b/datacommons_client/endpoints/observation.py
@@ -104,7 +104,7 @@ class ObservationEndpoint(Endpoint):
       parent_entity: str,
       entity_type: str,
       variable_dcids: str | list[str],
-  )-> ObservationResponse:
+  ) -> ObservationResponse:
     """
         Fetches all observations for a given entity type.
 
@@ -149,7 +149,7 @@ class ObservationEndpoint(Endpoint):
       date: ObservationDate | str,
       entity_dcids: str | list[str],
       variable_dcids: str | list[str],
-  )-> ObservationResponse:
+  ) -> ObservationResponse:
     """
         Fetches all observations for a given entity type.
 

--- a/datacommons_client/models/observation.py
+++ b/datacommons_client/models/observation.py
@@ -105,7 +105,7 @@ class Variable:
                     OrderedFacets.from_json(facet_data)
                     for facet_data in entity_data.get("orderedFacets", {})
                 ]
-            } for entity, entity_data in json_data["byEntity"].items()
+            } for entity, entity_data in json_data.get("byEntity", {}).items()
         })
 
 

--- a/datacommons_client/tests/endpoints/test_response.py
+++ b/datacommons_client/tests/endpoints/test_response.py
@@ -1,7 +1,4 @@
-from datacommons_client.endpoints.response import _unpack_arcs
 from datacommons_client.endpoints.response import DCResponse
-from datacommons_client.endpoints.response import extract_observations
-from datacommons_client.endpoints.response import flatten_properties
 from datacommons_client.endpoints.response import NodeResponse
 from datacommons_client.endpoints.response import ObservationResponse
 from datacommons_client.endpoints.response import ResolveResponse
@@ -9,6 +6,9 @@ from datacommons_client.models.observation import Facet
 from datacommons_client.models.observation import Observation
 from datacommons_client.models.observation import OrderedFacets
 from datacommons_client.models.observation import Variable
+from datacommons_client.utils.data_processing import extract_observations
+from datacommons_client.utils.data_processing import flatten_properties
+from datacommons_client.utils.data_processing import unpack_arcs
 
 ### ----- Test DCResponse ----- ###
 
@@ -153,7 +153,7 @@ def test_unpack_arcs_multiple_properties():
       },  # Empty nodes for completeness
   }
 
-  result = _unpack_arcs(arcs)
+  result = unpack_arcs(arcs)
 
   # Expected output
   expected = {

--- a/datacommons_client/tests/test_client.py
+++ b/datacommons_client/tests/test_client.py
@@ -1,0 +1,164 @@
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+import datacommons_client.client
+from datacommons_client.client import DataCommonsClient
+from datacommons_client.endpoints.base import API
+from datacommons_client.endpoints.node import NodeEndpoint
+from datacommons_client.endpoints.observation import ObservationEndpoint
+from datacommons_client.endpoints.resolve import ResolveEndpoint
+
+
+@pytest.fixture
+def mock_client():
+  """Fixture to create a DataCommonsClient instance with a mocked API."""
+  with patch("datacommons_client.endpoints.base.API.post") as mock_post:
+    client = DataCommonsClient(api_key="test_key")
+    client.observation = MagicMock(spec=ObservationEndpoint)
+    return client
+
+
+@patch(
+    "datacommons_client.endpoints.base.resolve_instance_url",
+    return_value="https://datacommons.org",
+)
+@patch(
+    "datacommons_client.utils.request_handling.check_instance_is_valid",
+    return_value="https://datacommons.org",
+)
+@patch(
+    "datacommons_client.utils.request_handling.build_headers",
+    return_value={"X-API-Key": "test_key"},
+)
+def test_datacommons_client_initialization(mock_build_headers,
+                                           mock_check_instance,
+                                           mock_resolve_instance_url):
+  """Tests that DataCommonsClient initializes correctly with API and endpoints, using a fake address."""
+  client = DataCommonsClient(api_key="test_key", dc_instance="test_instance")
+
+  assert isinstance(client.api, API)
+  assert client.api.headers == {
+      "Content-Type": "application/json",
+      "X-API-Key": "test_key",
+  }
+
+  assert isinstance(client.node, NodeEndpoint)
+  assert isinstance(client.observation, ObservationEndpoint)
+  assert isinstance(client.resolve, ResolveEndpoint)
+
+  assert client.node.api is client.api
+  assert client.observation.api is client.api
+  assert client.resolve.api is client.api
+
+
+def test_datacommons_client_raises_error_when_both_url_and_instance_are_provided(
+):
+  """Tests that DataCommonsClient raises a ValueError when both `dc_instance` and `url` are given."""
+  with pytest.raises(ValueError,
+                     match="Cannot provide both `dc_instance` and `url`."):
+    DataCommonsClient(api_key="test_key",
+                      dc_instance="test_instance",
+                      url="https://test.url")
+
+
+def test_observations_dataframe_raises_error_when_entities_all_but_no_entity_type(
+    mock_client,):
+  """Tests that ValueError is raised if 'entities' is 'all' but 'entity_type' is not specified."""
+  with pytest.raises(
+      ValueError,
+      match="When 'entity_dcids' is 'all', 'entity_type' must be specified."):
+    mock_client.observations_dataframe(variable_dcids="var1",
+                                       date="2024",
+                                       entity_dcids="all")
+
+
+def test_observations_dataframe_raises_error_when_invalid_entity_type_usage(
+    mock_client,):
+  """Tests that ValueError is raised if 'entity_type' or 'parent_entity' is specified with specific entities."""
+  with pytest.raises(
+      ValueError,
+      match="Specify 'entity_type' and 'parent_entity'"
+      " only when 'entity_dcids' is 'all'.",
+  ):
+    mock_client.observations_dataframe(variable_dcids="var1",
+                                       date="2024",
+                                       entity_dcids=["entity1"],
+                                       entity_type="Country")
+
+
+def test_observations_dataframe_calls_fetch_observations_by_entity_type(
+    mock_client):
+  """Tests that fetch_observations_by_entity_type is called with correct parameters."""
+  mock_client.observation.fetch_observations_by_entity_type.return_value.get_observations_as_records.return_value = (
+      [])
+
+  df = mock_client.observations_dataframe(variable_dcids=["var1", "var2"],
+                                          date="2024",
+                                          entity_dcids="all",
+                                          entity_type="Country",
+                                          parent_entity="Earth")
+
+  mock_client.observation.fetch_observations_by_entity_type.assert_called_once_with(
+      variable_dcids=["var1", "var2"],
+      date="2024",
+      entity_type="Country",
+      parent_entity="Earth",
+  )
+
+  assert isinstance(df, pd.DataFrame)
+  assert df.empty
+
+
+def test_observations_dataframe_calls_fetch_observations_by_entity(mock_client):
+  """Tests that fetch_observations_by_entity is called with correct parameters."""
+
+  mock_client.observation.fetch_observations_by_entity.return_value.get_observations_as_records.return_value = (
+      [])
+
+  df = mock_client.observations_dataframe(variable_dcids="var1",
+                                          date="latest",
+                                          entity_dcids=["entity1", "entity2"])
+
+  mock_client.observation.fetch_observations_by_entity.assert_called_once_with(
+      variable_dcids="var1", date="latest", entity_dcids=["entity1", "entity2"])
+
+  assert isinstance(df, pd.DataFrame)
+  assert df.empty
+
+
+def test_observations_dataframe_returns_dataframe_with_expected_columns(
+    mock_client):
+  """Tests that the method returns a DataFrame with expected columns."""
+  mock_client.observation.fetch_observations_by_entity.return_value.get_observations_as_records.return_value = [
+      {
+          "date": "2024",
+          "entity": "entity1",
+          "variable": "var1",
+          "value": 100,
+          "unit": "unit1",
+      },
+      {
+          "date": "2024",
+          "entity": "entity2",
+          "variable": "var2",
+          "value": 200,
+          "unit": "unit2",
+      },
+  ]
+
+  df = mock_client.observations_dataframe(variable_dcids="var1",
+                                          date="2024",
+                                          entity_dcids=["entity1", "entity2"])
+
+  assert isinstance(df, pd.DataFrame)
+  assert set(df.columns) == {"date", "entity", "variable", "value", "unit"}
+  assert len(df) == 2
+  assert df.iloc[0]["variable"] == "var1"
+  assert df.iloc[0]["value"] == 100
+  assert df.iloc[0]["unit"] == "unit1"
+  assert df.iloc[1]["variable"] == "var2"
+  assert df.iloc[1]["value"] == 200
+  assert df.iloc[1]["unit"] == "unit2"

--- a/datacommons_client/tests/test_decorators.py
+++ b/datacommons_client/tests/test_decorators.py
@@ -1,0 +1,47 @@
+import sys
+from unittest import mock
+
+import pytest
+
+from datacommons_client.utils.decorators import requires_pandas
+
+try:
+  import pandas as pd
+
+  PANDAS_AVAILABLE = True
+except ImportError:
+  PANDAS_AVAILABLE = False
+
+
+@requires_pandas
+def function_requiring_pandas():
+  return "Pandas is available"
+
+
+def test_requires_pandas_with_pandas():
+  """Test that the function executes normally when Pandas is available."""
+  if PANDAS_AVAILABLE:
+    assert function_requiring_pandas() == "Pandas is available"
+
+
+def test_requires_pandas_without_pandas(monkeypatch):
+  """Test that the decorator raises ImportError when Pandas is not available."""
+  # Simulate Pandas being unavailable
+  monkeypatch.setattr("datacommons_client.utils.decorators.pd", None)
+  with pytest.raises(ImportError, match="Pandas is required for this method"):
+    function_requiring_pandas()
+
+
+def test_importerror_handling(monkeypatch):
+  """Test that the ImportError block is executed when Pandas is not installed."""
+
+  # Simulate pandas not being available
+  with mock.patch.dict("sys.modules", {"pandas": None}):
+    import importlib
+
+    # Reload the module so that a new check of Pandas is performed
+    import datacommons_client.utils.decorators
+    importlib.reload(datacommons_client.utils.decorators)
+
+  # Ensure pd is set to None
+  assert datacommons_client.utils.decorators.pd is None

--- a/datacommons_client/utils/data_processing.py
+++ b/datacommons_client/utils/data_processing.py
@@ -1,0 +1,95 @@
+from dataclasses import asdict
+from typing import Any, Dict
+
+
+def unpack_arcs(arcs: Dict[str, Any]) -> Any:
+  """Simplify the 'arcs' structure."""
+  if len(arcs) > 1:
+    # Multiple arcs: return dictionary of property nodes
+    return {prop: arc_data["nodes"] for prop, arc_data in arcs.items()}
+
+  # Single arc: extract first node's data
+  for property_data in arcs.values():
+    nodes = property_data.nodes
+    if nodes is not None:
+      return nodes if len(nodes) > 1 else nodes[0]
+
+
+def flatten_properties(data: Dict[str, Any]) -> Dict[str, Any]:
+  """
+    Flatten the properties of a node response.
+
+    Processes a dictionary of node responses, extracting and
+    simplifying their properties and arcs into a flattened dictionary.
+
+    Args:
+        data (Dict[str, Dict[str, Any]]):
+            The input dictionary containing node responses. Each node maps to
+            a dictionary with potential "arcs" and "properties" keys.
+
+    Returns:
+        Dict[str, Any]:
+            A flattened dictionary where keys are node identifiers, and values
+            are the simplified properties or nodes.
+    """
+
+  # Store simplified properties
+  items = {}
+
+  for node, node_data in data.items():
+    arcs = getattr(node_data, "arcs", {})
+    properties = getattr(node_data, "properties", None)
+
+    processed_arcs = unpack_arcs(arcs) if arcs else None
+    items[node] = processed_arcs if processed_arcs is not None else properties
+
+  return items
+
+
+def extract_observations(variable: str, entity: str, entity_data: dict,
+                         facet_metadata: dict) -> list[dict]:
+  """
+    Extracts observations for a given variable, entity, and its data.
+
+    Args:
+        variable (str): The variable name.
+        entity (str): The entity name.
+        entity_data (dict): Data for the entity, including ordered facets.
+        facet_metadata (dict): Metadata for facets.
+
+    Returns:
+        list[dict]: A list of observation records.
+    """
+  return [{
+      "date": observation.date,
+      "entity": entity,
+      "variable": variable,
+      "value": observation.value,
+      "facetId": facet.facetId,
+      **asdict(facet_metadata.get(facet.facetId, {})),
+  }
+          for facet in entity_data.get("orderedFacets", [])
+          for observation in facet.observations]
+
+
+def observations_as_records(data: dict, facets: dict) -> list[dict]:
+  """
+    Converts observation data into a list of records.
+
+    Args:
+        data (dict): A mapping of variables to entities and their data.
+        facets (dict): Facet metadata for the observations.
+
+    Returns:
+        list[dict]: A flattened list of observation records.
+    """
+  return [
+      record for variable, entities in data.items()
+      for entity, entity_data in entities.items()
+      for record in extract_observations(
+          variable=variable,
+          entity=entity,
+          entity_data=entity_data,
+          facet_metadata=facets,
+      )
+  ]

--- a/datacommons_client/utils/decorators.py
+++ b/datacommons_client/utils/decorators.py
@@ -1,0 +1,18 @@
+from functools import wraps
+
+try:
+  import pandas as pd
+except ImportError:
+  pd = None
+
+
+def requires_pandas(func):
+  """Decorator to check if Pandas is available before executing a method."""
+
+  @wraps(func)
+  def wrapper(*args, **kwargs):
+    if pd is None:
+      raise ImportError("Pandas is required for this method")
+    return func(*args, **kwargs)
+
+  return wrapper


### PR DESCRIPTION
This PR introduces the`DataCommonsClient` class to interact with the Data Commons API, along with various utility functions and tests. 

### DataCommonsClient

The DataCommonsClient class would be the main entry point for most users. As described in the design doc:

> The datacommons entrypoint would coordinate interactions with and between classes. 
>It would simply provide convenient access to the different endpoints, centralising where the api_key and dc_instance are provided, and binding a specific ‘client’ instance to a specific knowledge graph and API key.
>It will also add convenient methods to perform additional, higher-level interactions with the data/api. For example, it can implement a method to get data as a nicely structured Pandas DataFrame (if the optional dependency is installed).

This implementation achieves those objectives but it shouldn't be seen as the end state of the class. The ultimate aim is to provide a range of convenience tools and functionality. For now, I wanted to keep this PR small and focused around defining how it will all come together, including clearly showcasing how the optional Pandas dependency will work.

For example, connecting to base DC:

```python
from datacommons_client.client import DataCommonsClient

client = DataCommonsClient(dc_instance="datacommons.org", api_key="api-key-string")
```

And using that client, getting all property labels for a given node (docs example)

```python
response = client.node.fetch_property_labels(node_dcids="geoId/06", out=False)
```
Which returns a `NodeResponse` object with the API response
```python
NodeResponse(
data={'geoId/06': Properties(properties=['affectedPlace',
                                                      'containedInPlace',
                                                      'location',
                                                      'member',
                                                      'overlapsWith'])},
nextToken=None
)
```
Or which can produce a flatted list of properties for each entity:
```python
properties = response.get_properties()

{'geoId/06': ['affectedPlace',
              'containedInPlace',
              'location',
              'member',
              'overlapsWith']}

```

As another example, getting statistical observations as a Pandas DataFrame from a custom DC instance

```python
client = DataCommonsClient(dc_instance="datacommons.one.org")

response = client.observations_dataframe(
    variable_dcids="sdg/SI_POV_DAY1",
    date="latest",
    entity_dcids=["country/GTM", "country/NGA"],
)

```

That will return a pandas Data Frame shaped as follows
|    |   date | entity      | variable        |   value |    facetId | importName   | measurementMethod   | observationPeriod   | provenanceUrl                          | unit        |
|---:|-------:|:------------|:----------------|--------:|-----------:|:-------------|:--------------------|:--------------------|:---------------------------------------|:------------|
|  0 |   2018 | country/NGA | sdg/SI_POV_DAY1 |    30.9 | 3549866825 | UN_SDG       | SDG_G_G             |                     | https://unstats.un.org/sdgs/dataportal | SDG_PERCENT |
|  1 |   2014 | country/GTM | sdg/SI_POV_DAY1 |     9.5 | 3549866825 | UN_SDG       | SDG_G_G             |                     | https://unstats.un.org/sdgs/dataportal | SDG_PERCENT |


Or we could also get all data for African countries for a specific indicator.

```python
response = client.observations_dataframe(
    variable_dcids="sdg/SI_POV_DAY1",
    date="all",
    entity_type="Country",
    parent_entity="africa",
)

response.head(5)
```
|    |   date | entity      | variable        |   value |    facetId | importName   | measurementMethod   | observationPeriod   | provenanceUrl                          | unit        |
|---:|-------:|:------------|:----------------|--------:|-----------:|:-------------|:--------------------|:--------------------|:---------------------------------------|:------------|
|  0 |   1996 | country/CMR | sdg/SI_POV_DAY1 |    50.4 | 3549866825 | UN_SDG       | SDG_G_G             |                     | https://unstats.un.org/sdgs/dataportal | SDG_PERCENT |
|  1 |   2001 | country/CMR | sdg/SI_POV_DAY1 |    25.7 | 3549866825 | UN_SDG       | SDG_G_G             |                     | https://unstats.un.org/sdgs/dataportal | SDG_PERCENT |
|  2 |   2007 | country/CMR | sdg/SI_POV_DAY1 |    31.4 | 3549866825 | UN_SDG       | SDG_G_G             |                     | https://unstats.un.org/sdgs/dataportal | SDG_PERCENT |
|  3 |   2014 | country/CMR | sdg/SI_POV_DAY1 |    25.7 | 3549866825 | UN_SDG       | SDG_G_G             |                     | https://unstats.un.org/sdgs/dataportal | SDG_PERCENT |
|  4 |   1992 | country/CAF | sdg/SI_POV_DAY1 |    82.2 | 3549866825 | UN_SDG       | SDG_G_G             |                     | https://unstats.un.org/sdgs/dataportal | SDG_PERCENT |

A lot of convenient features are possible but this PR does not incorporate them (the subject of future PRs)...

These examples are just scratching the surface to showcase the idea. Let me know if more would be helpful!