### PR TITLE
Upgrade packaging process for V2 beta release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.0.0 [forthcoming]
+
+
 ## 1.4.3
 
 **Date** - 11/10/2020

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,4 +4,4 @@ steps:
     entrypoint: /bin/sh
     args:
       - -c
-      - "./run_test.sh -s -a"
+      - "./run_test.sh -s && hatch run test:all"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,7 +1,7 @@
 steps:
   - id: api_python
     name: python:3.10-slim
-    entrypoint: /bin/sh
+    entrypoint: /bin/bash
     args:
       - -c
       - "./run_test.sh -s && hatch run test:all"

--- a/datacommons_client/README.md
+++ b/datacommons_client/README.md
@@ -5,14 +5,14 @@ This is a Python library for accessing data in the Data Commons Graph.
 To get started, install this package from pip.
 
 ```bash
-pip install datacommons_client
+pip install datacommons-client
 ```
 
 To get additional functionality to work with Pandas DataFrames, install the package
 with the optional Pandas dependency.
 
 ```bash
-pip install "datacommons_client[Pandas]"
+pip install "datacommons-client[Pandas]"
 ```
 
 Once the package is installed, import `datacommons_client`.

--- a/datacommons_client/README.md
+++ b/datacommons_client/README.md
@@ -1,0 +1,46 @@
+# Data Commons Python API
+
+This is a Python library for accessing data in the Data Commons Graph.
+
+To get started, install this package from pip.
+
+```bash
+pip install datacommons_client
+```
+
+To get additional functionality to work with Pandas DataFrames, install the package
+with the optional Pandas dependency.
+
+```bash
+pip install "datacommons_client[Pandas]"
+```
+
+Once the package is installed, import `datacommons_client`.
+
+```python
+import datacommons_client as dc
+```
+
+For more detail on getting started with the API, please visit our
+[API Overview](https://docs.datacommons.org/api/).
+
+When you are ready to use the API, you can refer to `examples` for
+examples on how to use this package to perform various tasks. More tutorials and
+documentation can be found on our [tutorials page](https://docs.datacommons.org/tutorials/)!
+
+## About Data Commons
+
+[Data Commons](https://datacommons.org/) is an open knowledge repository that
+provides a unified view across multiple public data sets and statistics. You can
+view what [datasets](https://datacommons.org/datasets) are currently ingested
+and browse the graph using our [browser](https://datacommons.org/browser).
+
+## License
+
+Apache 2.0
+
+## Support
+
+For general questions or issues about the API, please open an issue on our
+[issues](https://github.com/google/datacommons/issues) page. For all other
+questions, please send an email to `support@datacommons.org`.

--- a/datacommons_client/__init__.py
+++ b/datacommons_client/__init__.py
@@ -1,0 +1,20 @@
+__version__ = "2.0.0b1"
+"""
+Data Commons Client Package
+
+This package provides a Python client for interacting with the Data Commons API.
+"""
+
+from datacommons_client.client import DataCommonsClient
+from datacommons_client.endpoints.base import API
+from datacommons_client.endpoints.node import NodeEndpoint
+from datacommons_client.endpoints.observation import ObservationEndpoint
+from datacommons_client.endpoints.resolve import ResolveEndpoint
+
+__all__ = [
+    "DataCommonsClient",
+    "API",
+    "NodeEndpoint",
+    "ObservationEndpoint",
+    "ResolveEndpoint",
+]

--- a/datacommons_client/endpoints/node.py
+++ b/datacommons_client/endpoints/node.py
@@ -3,8 +3,7 @@ from typing import Optional
 from datacommons_client.endpoints.base import API
 from datacommons_client.endpoints.base import Endpoint
 from datacommons_client.endpoints.payloads import NodeRequestPayload
-from datacommons_client.endpoints.payloads import \
-    normalize_properties_to_string
+from datacommons_client.endpoints.payloads import normalize_properties_to_string
 from datacommons_client.endpoints.response import NodeResponse
 
 

--- a/datacommons_client/endpoints/payloads.py
+++ b/datacommons_client/endpoints/payloads.py
@@ -5,8 +5,7 @@ from dataclasses import field
 from enum import Enum
 from typing import Optional
 
-from datacommons_client.utils.error_handling import \
-    InvalidObservationSelectError
+from datacommons_client.utils.error_handling import InvalidObservationSelectError
 
 
 def normalize_properties_to_string(properties: str | list[str]) -> str:

--- a/datacommons_client/tests/endpoints/test_payloads.py
+++ b/datacommons_client/tests/endpoints/test_payloads.py
@@ -5,8 +5,7 @@ from datacommons_client.endpoints.payloads import ObservationDate
 from datacommons_client.endpoints.payloads import ObservationRequestPayload
 from datacommons_client.endpoints.payloads import ObservationSelect
 from datacommons_client.endpoints.payloads import ResolveRequestPayload
-from datacommons_client.utils.error_handling import \
-    InvalidObservationSelectError
+from datacommons_client.utils.error_handling import InvalidObservationSelectError
 
 
 def test_node_payload_normalize():

--- a/datacommons_client/tests/endpoints/test_resolve_endpoint.py
+++ b/datacommons_client/tests/endpoints/test_resolve_endpoint.py
@@ -1,8 +1,7 @@
 from unittest.mock import MagicMock
 
 from datacommons_client.endpoints.base import API
-from datacommons_client.endpoints.resolve import \
-    _resolve_correspondence_expression
+from datacommons_client.endpoints.resolve import _resolve_correspondence_expression
 from datacommons_client.endpoints.resolve import flatten_resolve_response
 from datacommons_client.endpoints.resolve import ResolveEndpoint
 from datacommons_client.endpoints.response import ResolveResponse

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,23 +1,49 @@
 # Python API Development
 
-The Python API currently supports `python>=3.7`.
+This client library supports `python>=3.10`.
 
-To set up the Python environment for tests, run:
+## Set up
+If you haven't already, clone this repository.
+
+```bash
+git clone https://github.com/datacommonsorg/api-python.git
+cd api-python
+```
+
+To set up the Python environment for development, run:
 
 ```bash
 ./run_test.sh -s
 ```
 
+This will install `hatch`, which is the main tool used to manage the
+environment, dependencies, and development tools. You can also manually install
+`hatch` and create a virtual environment.
+
+```bash
+pip install hatch
+hatch env create
+```
+
+## Code style and linting
+We use `isort` and `yapf` for code formatting. Check formatting with:
+
+```bash
+hatch run lint:check
+```
+
+To automatically fix formatting run:
+
+```bash
+hatch run lint:format
+```
+
+## Running tests
+
 To test, run:
 
 ```bash
-./run_test.sh -a
-```
-
-To format, run:
-
-```bash
-./run_test.sh -f
+hatch run test:all
 ```
 
 To debug the continuous integration tests, run:
@@ -27,11 +53,3 @@ gcloud builds submit . --project=datcom-ci --config=cloudbuild.yaml
 ```
 
 Both commands will run the same set of tests.
-
-To run the examples:
-
-```bash
-python -m datacommons.examples.XXX
-```
-
-where XXX is the module you want to run.

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,5 +1,41 @@
 # Python API Release
 
+## Releasing the `datacommons_client` package
+Support for V2 of the Data Commons API is being released as a new client library
+called `datacommons_client`.
+
+To release:
+1. Update [CHANGELOG.md](../CHANGELOG.md) with relevant changes.
+2. Bump the version by running `hatch version` followed by `patch`, `minor`, `major`, a 
+specific version number, or `--pre beta` for a beta version, for example.
+3. Build the package
+```bash
+hatch build
+```
+4. (optionally) Test the deployment process locally
+```bash
+hatch run release:localtest
+```
+5. Test the deployment process on Test PyPi
+```bash
+hatch run release:testpypi
+```
+
+6. Once verified, upload to PyPI:
+```bash
+hatch run release:pypi
+```
+
+7. Create a version tag on Git:
+```bash
+hatch run release:tag
+```
+
+---
+
+## Releasing the legacy packages
+
+
 Note: Always release `datacommons_pandas` when `datacommons` is released.
 
 **If this is your first time releasing to PyPI**, please review the PyPI guide

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,9 @@ dependencies = [
 dependencies = [
     "pytest",
     "mock",
-    "pandas"
+    "pandas",
+    "isort",
+    "yapf"
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,12 @@ dynamic = ["version"]
 description = "A library to access Data Commons Python API."
 readme = "datacommons_client/README.md"
 authors = [
-    { name = "datacommons.org", email = "support@datacommons.org" }
+    { name = "datacommons.org", email = "support@datacommons.org" },
+    { name = "one.org", email= "data@one.org"}
 ]
 maintainers = [
-    { name = "datacommons.org", email = "support@datacommons.org" }
+    { name = "datacommons.org", email = "support@datacommons.org" },
+    { name = "one.org", email = "data@one.org"}
 ]
 license = { file = "LICENSE" }
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,105 @@
+[project]
+name = "datacommons_client"
+dynamic = ["version"]
+description = "A library to access Data Commons Python API."
+readme = "datacommons_client/README.md"
+authors = [
+    { name = "datacommons.org", email = "support@datacommons.org" }
+]
+maintainers = [
+    { name = "datacommons.org", email = "support@datacommons.org" }
+]
+license = { file = "LICENSE" }
+dependencies = [
+"requests>=2.32",
+"typing_extensions"
+]
+requires-python = ">=3.10"
+keywords = ["data commons", "api", "data", "development"]
+classifiers = [
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Topic :: Software Development"
+]
+urls = { "Homepage" = "https://github.com/datacommonsorg/api-python" }
+
+[project.optional-dependencies]
+pandas = ["pandas"]
+dev = [
+    "pytest",
+    "isort",
+    "yapf",
+    "mock",
+    "hatch"
+]
+
+[tool.hatch.version]
+path = "datacommons_client/__init__.py"
+
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "datacommons_client",
+    "README.md",
+    "LICENSE",
+    "CHANGELOG.md"
+]
+
+[tool.hatch.build.targets.wheel]
+include = [
+    "datacommons_client"
+]
+
+[tool.hatch.envs.default]
+dependencies = [
+    "pytest",
+    "isort",
+    "yapf",
+    "hatch",
+]
+
+[tool.hatch.envs.test]
+dependencies = [
+    "pytest",
+    "mock",
+    "pandas"
+]
+
+
+[tool.hatch.envs.test.scripts]
+setup = "sh ./run_test.sh -s"
+all = "sh ./run_test.sh -a"
+python = "sh ./run_test.sh -p"
+lint = "sh ./run_test.sh -l"
+
+[tool.hatch.envs.lint]
+dependencies = [
+    "isort",
+    "yapf"
+]
+
+[tool.hatch.envs.lint.scripts]
+check = "./run_test.sh -l"
+format = "./run_test.sh -f"
+
+[tool.hatch.envs.release]
+dependencies = [
+    "twine"
+]
+
+[tool.hatch.envs.release.scripts]
+localtest = "hatch build && twine check dist/*"
+testpypi = "hatch build && twine upload --repository testpypi dist/*"
+pypi = "hatch build && twine upload dist/*"
+tag = "git commit -am 'Bump version to {version}' && git tag v{version}"
+
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "datacommons_client"
+name = "datacommons-client"
 dynamic = ["version"]
 description = "A library to access Data Commons Python API."
 readme = "datacommons_client/README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,10 +75,10 @@ dependencies = [
 
 
 [tool.hatch.envs.test.scripts]
-setup = "sh ./run_test.sh -s"
-all = "sh ./run_test.sh -a"
-python = "sh ./run_test.sh -p"
-lint = "sh ./run_test.sh -l"
+setup = "./run_test.sh -s"
+all = "./run_test.sh -a"
+python = "./run_test.sh -p"
+lint = "./run_test.sh -l"
 
 [tool.hatch.envs.lint]
 dependencies = [

--- a/run_test.sh
+++ b/run_test.sh
@@ -20,17 +20,12 @@ FORMAT_INCLUDE_PATHS="datacommons/ datacommons_client/ datacommons_pandas/"
 FORMAT_EXCLUDE_PATH="**/.env/**"
 
 function setup_python {
-  python3 -m venv .env
-  source .env/bin/activate
-  pip install --upgrade pip
-  pip3 install -r requirements.txt -q
-  deactivate
+  python3 -m pip install --upgrade pip hatch
+  hatch env create
 }
 
 function run_py_test {
-  source .env/bin/activate
-  python3 -m pytest -vv
-  deactivate
+  pytest -vv
 }
 
 function run_yapf {
@@ -46,7 +41,6 @@ function run_isort {
 }
 
 function run_lint_test {
-  source .env/bin/activate
   if ! run_yapf --diff; then
     echo "Fix lint errors by running: ./run_test.sh -f"
     exit 1
@@ -55,15 +49,12 @@ function run_lint_test {
     echo "Fix Python import sort orders by running ./run_test.sh -f"
     exit 1
   fi
-  deactivate
   echo "Python style checks passed."
 }
 
 function run_lint_fix {
-  source .env/bin/activate
   run_yapf --in-place
   run_isort
-  deactivate
 }
 
 function run_all_tests {


### PR DESCRIPTION
This PR focuses on improvements to the packaging process. It:
- Introduces a `pyproject.toml` file for PEP 518-compliant builds. This files mirrors the information included in the legacy packages `setup.py` files. Note that the minimum python version supported will be `3.10` given that `<3.8` reached their end of life last year, and `3.9` will reach its end of life later this year. We could in theory support `3.9` still - so let me know if I should change that. Also note that I've added one.org as authors and maintainers (in addition to the datacommons team of course).
- Introduces `hatch` as the primary tool for packaging and managing development dependencies. I tried to make its introduction as unobtrusive as possible. The main rationale was to improve and simplify the packaging process. `hatch` also helps with resolving dependencies and managing the virtual environment. When combined with declaring dependencies in `pyproject.toml`, the `requirements.txt` file is no longer necessary. However, I've kept it intact as it is still required for development and releases of the legacy packages.
- Linked to the above, I introduced minor tweaks to `cloudbuild.yaml` to call the right sequence of commands for testing.
- Linked to the `hatch` and `pyproject.toml`, I introduced changes to `run_test.sh` to simplify how environments are managed (since `hatch` does that).

I've tested all of these changes locally, except for deployment to Test PyPi (and of course to PyPi). That would require that I am added as a collaborator... or if you want to manage releases entirely on your side, it will need to be tested (and eventually deployed) by your team with your credentials.

**Additional question**

I've prepared this to become a `v2.0.0b1` beta version. My logic with V2 is that there was a v1.x with the `datacommons` package. But I don't know if you want to keep that package name, or move to `datacommons_client` and leave `datacommons` as the API V1 package. How should that work?


As always, thank you for reviewing this and happy to discuss further!