### PR TITLE
Improve `url` handling

### DIFF
--- a/datacommons_client/client.py
+++ b/datacommons_client/client.py
@@ -45,6 +45,11 @@ class DataCommonsClient:
             dc_instance (Optional[str]): The Data Commons instance to use. Defaults to "datacommons.org".
             url (Optional[str]): A custom, fully resolved URL for the Data Commons API. Defaults to None.
         """
+    # If a fully resolved URL is provided, and the default dc_instance is used,
+    # ignore that default value
+    if dc_instance == "datacommons.org" and url:
+      dc_instance = None
+
     # Create an instance of the API class which will be injected to the endpoints
     self.api = API(api_key=api_key, dc_instance=dc_instance, url=url)
 

--- a/datacommons_client/tests/test_client.py
+++ b/datacommons_client/tests/test_client.py
@@ -69,7 +69,8 @@ def test_observations_dataframe_raises_error_when_entities_all_but_no_entity_typ
   """Tests that ValueError is raised if 'entities' is 'all' but 'entity_type' is not specified."""
   with pytest.raises(
       ValueError,
-      match="When 'entity_dcids' is 'all', 'entity_type' must be specified."):
+      match="When 'entity_dcids' is 'all', 'entity_type' must be specified.",
+  ):
     mock_client.observations_dataframe(variable_dcids="var1",
                                        date="2024",
                                        entity_dcids="all")
@@ -83,10 +84,12 @@ def test_observations_dataframe_raises_error_when_invalid_entity_type_usage(
       match="Specify 'entity_type' and 'parent_entity'"
       " only when 'entity_dcids' is 'all'.",
   ):
-    mock_client.observations_dataframe(variable_dcids="var1",
-                                       date="2024",
-                                       entity_dcids=["entity1"],
-                                       entity_type="Country")
+    mock_client.observations_dataframe(
+        variable_dcids="var1",
+        date="2024",
+        entity_dcids=["entity1"],
+        entity_type="Country",
+    )
 
 
 def test_observations_dataframe_calls_fetch_observations_by_entity_type(
@@ -95,11 +98,13 @@ def test_observations_dataframe_calls_fetch_observations_by_entity_type(
   mock_client.observation.fetch_observations_by_entity_type.return_value.get_observations_as_records.return_value = (
       [])
 
-  df = mock_client.observations_dataframe(variable_dcids=["var1", "var2"],
-                                          date="2024",
-                                          entity_dcids="all",
-                                          entity_type="Country",
-                                          parent_entity="Earth")
+  df = mock_client.observations_dataframe(
+      variable_dcids=["var1", "var2"],
+      date="2024",
+      entity_dcids="all",
+      entity_type="Country",
+      parent_entity="Earth",
+  )
 
   mock_client.observation.fetch_observations_by_entity_type.assert_called_once_with(
       variable_dcids=["var1", "var2"],
@@ -162,3 +167,16 @@ def test_observations_dataframe_returns_dataframe_with_expected_columns(
   assert df.iloc[1]["variable"] == "var2"
   assert df.iloc[1]["value"] == 200
   assert df.iloc[1]["unit"] == "unit2"
+
+
+@patch(
+    "datacommons_client.endpoints.base.check_instance_is_valid",
+    return_value="https://test.url",
+)
+def test_dc_instance_is_ignored_when_url_is_provided(mock_check_instance):
+  """Tests that dc_instance is ignored when a fully resolved URL is provided."""
+
+  client = DataCommonsClient(api_key="test_key", url="https://test.url")
+
+  # Check that the API base_url is set to the fully resolved url
+  assert client.api.base_url == "https://test.url"


### PR DESCRIPTION
@kmoscoe identified an improvement we can make to how the `DataCommonsClient` class handles a fully resolved URL.

For context, during the design phase, @dwnoble requested having a way to provide a fully resolved URL, instead of the URL of Google's Data Commons (datacommons.org) or the URL of a custom Data Commons instance (like datacommons.one.org). 

That means that the `DataCommonsClient` class is initiated with:
```python
""" 
Args:
            api_key (Optional[str]): The API key for authentication. Defaults to None. Note that
                custom DC instances do not currently require an API key.
            dc_instance (Optional[str]): The Data Commons instance to use. Defaults to "datacommons.org".
            url (Optional[str]): A custom, fully resolved URL for the Data Commons API. Defaults to None.
"""
```

However, as @kmoscoe pointed out, if a `url` is used, it will return an error unless `dc_instance` is set to `None`. That's because both `dc_instance` and `url` cannot be set at the same time... and currently the default value of `dc_instance` is, for convenience, `datacommons.org`.

This PR introduces a small check (and it's associated test), to ignore `dc_instance` (if its default value is used) in cases when a `url` is provided.

That would allow for something like this to work:
```python
from datacommons_client.client import DataCommonsClient
client = DataCommonsClient(url="http://localhost:8080/core/api/v2/")
```
Instead of raising an error and requiring to also set `dc_instance` to `None`.