### PR TITLE
Update README.md

### DIFF
--- a/datacommons_client/README.md
+++ b/datacommons_client/README.md
@@ -24,9 +24,7 @@ import datacommons_client as dc
 For more detail on getting started with the API, please visit our
 [API Overview](https://docs.datacommons.org/api/).
 
-When you are ready to use the API, you can refer to `examples` for
-examples on how to use this package to perform various tasks. More tutorials and
-documentation can be found on our [tutorials page](https://docs.datacommons.org/tutorials/)!
+**Note: This package uses the V2 REST API and is in Beta. All of the existing tutorials and samples use V1. We will be updating all the documentation during this Beta.
 
 ## About Data Commons
 

--- a/datacommons_client/README.md
+++ b/datacommons_client/README.md
@@ -24,7 +24,7 @@ import datacommons_client as dc
 For more detail on getting started with the API, please visit our
 [API Overview](https://docs.datacommons.org/api/).
 
-**Note: This package uses the V2 REST API and is in Beta. All of the existing tutorials and samples use V1. We will be updating all the documentation during this Beta.
+**Note:** This package uses the V2 REST API and is in Beta. All of the existing Python and Pandas tutorials and samples use V1. We will be updating all the documentation during this Beta.
 
 ## About Data Commons
 


### PR DESCRIPTION
Removed links to docs/tutorials that use the old V1 API. Added a disclaimer that this is "beta" and examples have yet to be updated.