### PR TITLE
Improve response output

### DIFF
--- a/datacommons_client/endpoints/response.py
+++ b/datacommons_client/endpoints/response.py
@@ -1,6 +1,7 @@
 from dataclasses import asdict
 from dataclasses import dataclass
 from dataclasses import field
+import json
 from typing import Any, Dict, List
 
 from datacommons_client.models.node import Arcs
@@ -69,9 +70,29 @@ class NodeResponse:
   def get_properties(self) -> Dict:
     return flatten_properties(self.data)
 
-  @property
-  def json(self):
-    return asdict(self)
+  def to_dict(self, exclude_none: bool = True) -> Dict[str, Any]:
+    """Converts the NodeResponse instance to a dictionary.
+
+        Args:
+            exclude_none: If True, only include non-empty values in the response. Defaults to True.
+
+        Returns:
+            Dict[str, Any]: The dictionary representation of the NodeResponse instance
+        """
+    return _to_dict(self, exclude_none=exclude_none)
+
+  def to_json(self, exclude_none: bool = True) -> str:
+    """Converts the NodeResponse instance to a JSON string.
+
+        Args:
+            exclude_none: If True, only include non-empty values in the response. Defaults to True.
+
+        Returns:
+            str: The JSON string representation of the NodeResponse instance
+
+        """
+
+    return json.dumps(self.to_dict(exclude_none=exclude_none), indent=2)
 
 
 @dataclass
@@ -100,10 +121,6 @@ class ObservationResponse:
         },
     )
 
-  @property
-  def json(self):
-    return asdict(self)
-
   def get_data_by_entity(self) -> Dict:
     """Unpacks the data for each entity, for each variable.
 
@@ -122,6 +139,31 @@ class ObservationResponse:
         """
     return observations_as_records(data=self.get_data_by_entity(),
                                    facets=self.facets)
+
+  def to_dict(self, exclude_none: bool = True) -> Dict[str, Any]:
+    """Converts the ObservationResponse instance to a dictionary.
+
+        Args:
+            exclude_none: If True, only include non-empty values in the response. Defaults to True.
+
+        Returns:
+            Dict[str, Any]: The dictionary representation of the ObservationResponse instance
+        """
+
+    return _to_dict(self, exclude_none=exclude_none)
+
+  def to_json(self, exclude_none: bool = True) -> str:
+    """Converts the ObservationResponse instance to a JSON string.
+
+        Args:
+            exclude_none: If True, only include non-empty values in the response. Defaults to True.
+
+        Returns:
+            str: The JSON string representation of the ObservationResponse instance
+
+        """
+
+    return json.dumps(self.to_dict(exclude_none=exclude_none), indent=2)
 
 
 @dataclass
@@ -150,14 +192,26 @@ class ResolveResponse:
         Entity.from_json(entity) for entity in json_data.get("entities", [])
     ])
 
-  @property
-  def json(self):
+  def to_dict(self, exclude_none: bool = True) -> Dict[str, Any]:
     """Converts the ResolveResponse instance to a dictionary.
 
-        This is useful for serializing the response data back into a JSON-compatible
-        format.
+        Args:
+            exclude_none: If True, only include non-empty values in the response. Defaults to True.
 
         Returns:
-            Dict[str, Any]: The dictionary representation of the ResolveResponse instance.
+            Dict[str, Any]: The dictionary representation of the ResolveResponse instance
         """
-    return asdict(self)
+    return _to_dict(self, exclude_none=exclude_none)
+
+  def to_json(self, exclude_none: bool = True) -> str:
+    """Converts the ResolveResponse instance to a JSON string.
+
+        Args:
+            exclude_none: If True, only include non-empty values in the response. Defaults to True.
+
+        Returns:
+            str: The JSON string representation of the ResolveResponse instance
+
+        """
+
+    return json.dumps(self.to_dict(exclude_none=exclude_none), indent=2)

--- a/datacommons_client/endpoints/response.py
+++ b/datacommons_client/endpoints/response.py
@@ -50,6 +50,7 @@ def _to_dict(dc_response, exclude_none: bool) -> Dict[str, Any]:
   # Remove empty values from the dictionary if exclude_none is True.
   return _remove_none(response) if exclude_none else response
 
+
 @dataclass
 class DCResponse:
   """Represents a structured response from the Data Commons API."""

--- a/datacommons_client/endpoints/response.py
+++ b/datacommons_client/endpoints/response.py
@@ -15,8 +15,40 @@ from datacommons_client.models.observation import variableDCID
 from datacommons_client.models.resolve import Entity
 from datacommons_client.utils.data_processing import flatten_properties
 from datacommons_client.utils.data_processing import observations_as_records
-from datacommons_client.utils.data_processing import unpack_arcs
 
+
+def _to_dict(dc_response, exclude_none: bool) -> Dict[str, Any]:
+  """Converts the DCResponse instance to a dictionary.
+
+    This is useful for serializing the response data back into a JSON-compatible
+    format.
+
+    Args:
+        dc_response: The DCResponse instance to convert to a dictionary.
+        exclude_none: If True, only include non-empty values in the response.
+
+    Returns:
+        Dict[str, Any]: The dictionary representation of the DCResponse instance.
+    """
+
+  def _remove_none(
+      data: List[Dict[str, Any]] | Dict[str, Any]) -> List | Dict[str, Any]:
+    """Recursively removes an empty value from a dictionary."""
+
+    if isinstance(data, dict):
+      return {k: _remove_none(v) for k, v in data.items() if v}
+
+    elif isinstance(data, list):
+      return [_remove_none(item) for item in data]
+
+    else:
+      return data
+
+  # Convert the DCResponse instance to a dictionary.
+  response = asdict(dc_response)
+
+  # Remove empty values from the dictionary if exclude_none is True.
+  return _remove_none(response) if exclude_none else response
 
 @dataclass
 class DCResponse:

--- a/datacommons_client/endpoints/response.py
+++ b/datacommons_client/endpoints/response.py
@@ -36,7 +36,11 @@ def _to_dict(dc_response, exclude_none: bool) -> Dict[str, Any]:
     """Recursively removes an empty value from a dictionary."""
 
     if isinstance(data, dict):
-      return {k: _remove_none(v) for k, v in data.items() if v}
+      return {
+          k: _remove_none(v)
+          for k, v in data.items()
+          if v is not None and v != []
+      }
 
     elif isinstance(data, list):
       return [_remove_none(item) for item in data]

--- a/datacommons_client/tests/endpoints/test_response.py
+++ b/datacommons_client/tests/endpoints/test_response.py
@@ -1,3 +1,5 @@
+import json
+
 from datacommons_client.endpoints.response import DCResponse
 from datacommons_client.endpoints.response import NodeResponse
 from datacommons_client.endpoints.response import ObservationResponse
@@ -78,7 +80,48 @@ def test_node_as_dict():
   }
 
   response = NodeResponse.from_json(json_data)
-  result = response.json
+  result = response.to_dict()
+
+  assert result == json_data
+
+
+def test_node_as_dict_exclude_none():
+  """Test that the NodeResponse.json property returns the correct dictionary."""
+  json_data = {
+      "data": {
+          "geoId/06": {
+              "properties": None
+          }
+      },
+      "nextToken": "token123",
+  }
+
+  expected = {
+      "data": {
+          "geoId/06": {}
+      },
+      "nextToken": "token123",
+  }
+
+  response = NodeResponse.from_json(json_data)
+  result = response.to_dict(exclude_none=True)
+
+  assert result == expected
+
+
+def test_node_as_dict_include_none():
+  """Test that the NodeResponse.json property returns the correct dictionary."""
+  json_data = {
+      "data": {
+          "geoId/06": {
+              "properties": None
+          }
+      },
+      "nextToken": "token123",
+  }
+
+  response = NodeResponse.from_json(json_data)
+  result = response.to_dict(exclude_none=False)
 
   assert result == json_data
 
@@ -238,12 +281,44 @@ def test_observation_as_dict():
   response = ObservationResponse.from_json(json_data)
 
   # Getting it back as a dictionary
-  result = response.json
+  result = response.to_dict()
 
   assert "byVariable" in result
   assert "facets" in result
   assert "var1" in result["byVariable"]
   assert "entity1" in result["byVariable"]["var1"]["byEntity"]
+
+
+def test_observation_as_dict_exclude_none():
+  """Test that the ObservationResponse.json property returns the correct dictionary."""
+  json_data = {
+      "byVariable": {
+          "var1": {
+              "byEntity": {
+                  "entity1": {
+                      "orderedFacets": [{
+                          "facetId": "facet1"
+                      }]
+                  }
+              }
+          }
+      },
+      "facets": {
+          "facet1": {
+              "unit": "GTQ",
+              "importName": "Import Name",
+          }
+      },
+  }
+
+  # Parsing JSON data
+  response = ObservationResponse.from_json(json_data)
+
+  # Getting it back as a dictionary
+  result = response.to_dict(exclude_none=True)
+
+  assert ("latestDate" not in result["byVariable"]["var1"]["byEntity"]
+          ["entity1"]["orderedFacets"][0])
 
 
 def test_observation_response_from_json():
@@ -483,8 +558,8 @@ def test_resolve_response_from_json():
   assert entity2.candidates[0].dominantType == "Type2"
 
 
-def test_resolve_response_json():
-  """Test that ResolveResponse.from_json and json are consistent."""
+def test_resolve_response_dict():
+  """Test that ResolveResponse.to_dict and json are consistent."""
   # Input dictionary
   input_data = {
       "entities": [
@@ -516,7 +591,114 @@ def test_resolve_response_json():
   response = ResolveResponse.from_json(input_data)
 
   # Convert back to dictionary using the json property
-  result = response.json
+  result = response.to_dict(exclude_none=False)
 
   # Assert that the resulting dictionary matches the original input
   assert result == input_data
+
+
+def test_resolve_response_dict_exclude_none():
+  """Test that ResolveResponse.to_dict and json are consistent."""
+  # Input dictionary
+  input_data = {
+      "entities": [
+          {
+              "node":
+                  "entity1",
+              "candidates": [
+                  {
+                      "dcid": "dcid1",
+                      "dominantType": "Type1"
+                  },
+                  {
+                      "dcid": "dcid2",
+                      "dominantType": None
+                  },
+              ],
+          },
+          {
+              "node": "entity2",
+              "candidates": [{
+                  "dcid": "dcid3",
+                  "dominantType": "Type2"
+              },],
+          },
+      ]
+  }
+
+  # Expected data
+  expected_data = {
+      "entities": [
+          {
+              "node":
+                  "entity1",
+              "candidates": [
+                  {
+                      "dcid": "dcid1",
+                      "dominantType": "Type1"
+                  },
+                  {
+                      "dcid": "dcid2"
+                  },
+              ],
+          },
+          {
+              "node": "entity2",
+              "candidates": [{
+                  "dcid": "dcid3",
+                  "dominantType": "Type2"
+              },],
+          },
+      ]
+  }
+
+  # Create ResolveResponse from the dictionary
+  response = ResolveResponse.from_json(input_data)
+
+  # Convert back to dictionary using the json property
+  result = response.to_dict(exclude_none=True)
+
+  # Assert that the resulting dictionary matches the original input
+  assert result == expected_data
+
+
+def test_resolve_response_json_string_exclude_none():
+  """Test that ResolveResponse.to_dict and json are consistent."""
+  # Input dictionary
+  input_data = {
+      "entities": [
+          {
+              "node":
+                  "entity1",
+              "candidates": [
+                  {
+                      "dcid": "dcid1",
+                      "dominantType": "Type1"
+                  },
+                  {
+                      "dcid": "dcid2",
+                      "dominantType": None
+                  },
+              ],
+          },
+          {
+              "node": "entity2",
+              "candidates": [{
+                  "dcid": "dcid3",
+                  "dominantType": "Type2"
+              },],
+          },
+      ]
+  }
+
+  # Expected data
+  expected = json.dumps(input_data, indent=2)
+
+  # Create ResolveResponse from the dictionary
+  response = ResolveResponse.from_json(input_data)
+
+  # Convert back to dictionary using the json property
+  result = response.to_json(exclude_none=False)
+
+  # Assert that the resulting dictionary matches the original input
+  assert result == expected


### PR DESCRIPTION
This PR is in response to a discussion with @kmoscoe and @dwnoble regarding users access the REST API response as dictionaries/json strings.

To recap:
- We make POST requests to the relevant endpoint
- That returns a JSON string, which Python would parse as a dictionary. However, in order to provide strict typing and consistent structure, we transform the response into Python dataclasses.
- Before this PR, we would convert those dataclasses to Python dictionaries and provide that back as a `.json` property. The dictionary would be more verbose than the API response, as it would include null values (which the REST API response doesn't include)

This PR introduces a way to remove `None` values from serialised responses so they are more compact (and so that they mirror the REST API response). Additionally, it changes how the data is returned to improve clarity for users (by using clearer/more appropriate names):
- Remove the `.json` property. The rationale is that we weren't actually returning a json string but a dictionary. Also, given that it was a property, we couldn't take additional parameters to specify whether a 'compact' version should be returned.
- Add a `.to_dict()` method, which returns a dictionary. It takes a parameter `exclude_none` (which defaults to `True`) which excludes any keys which are None or empty lists*. I decided to call it `exclude_none` rather than `compact` to mirror how Pydantic deals with the same issue (model_dump optionally takes `exclude_none=True` in order to remove all `None` values). This prepares us for a future move to Pydantic (instead of Python dataclasses), as we've discussed.
- Add a `.to_json()` method, which returns a json string (via `json.dumps`). It takes the same `exclude_none` parameter described above.

@kmoscoe we would need to update the draft docs in order to call `.to_dict()` instead of `.json`. That would output Python dictionaries that look essentially the same as what would come out of the POST request to the REST API.

<br>

*This could have been a truthy/falsy check. That would omit and empty lists, empty strings, empty sets... but it would also exclude zero (which is falsy). Since zero doesn't equal missing in observations, we would want responses to include it. So instead, we should explicitly check for None and empty lists. 