### PR TITLE
`Resolve.fetch`: `node_dcids` to `node_ids`

### DIFF
--- a/datacommons_client/endpoints/resolve.py
+++ b/datacommons_client/endpoints/resolve.py
@@ -61,24 +61,24 @@ class ResolveEndpoint(Endpoint):
     """Initializes the ResolveEndpoint instance."""
     super().__init__(endpoint="resolve", api=api)
 
-  def fetch(self, node_dcids: str | list[str],
+  def fetch(self, node_ids: str | list[str],
             expression: str | list[str]) -> ResolveResponse:
     """
         Fetches resolved data for the given nodes and expressions.
 
         Args:
-            node_dcids (str | list[str]): One or more node IDs to resolve.
+            node_ids (str | list[str]): One or more node IDs to resolve.
             expression (str): The relation expression to query.
 
         Returns:
             ResolveResponse: The response object containing the resolved data.
         """
-    # Check if the node_dcids is a single string. If so, convert it to a list.
-    if isinstance(node_dcids, str):
-      node_dcids = [node_dcids]
+    # Check if the node_ids is a single string. If so, convert it to a list.
+    if isinstance(node_ids, str):
+      node_ids = [node_ids]
 
     # Construct the payload
-    payload = ResolveRequestPayload(node_dcids=node_dcids,
+    payload = ResolveRequestPayload(node_dcids=node_ids,
                                     expression=expression).to_dict
 
     # Send the request and return the response
@@ -102,7 +102,7 @@ class ResolveEndpoint(Endpoint):
                                                     to_type="dcid",
                                                     entity_type=entity_type)
 
-    return self.fetch(node_dcids=names, expression=expression)
+    return self.fetch(node_ids=names, expression=expression)
 
   def fetch_dcid_by_wikidata_id(
       self,
@@ -122,7 +122,7 @@ class ResolveEndpoint(Endpoint):
                                                     to_type="dcid",
                                                     entity_type=entity_type)
 
-    return self.fetch(node_dcids=wikidata_id, expression=expression)
+    return self.fetch(node_ids=wikidata_id, expression=expression)
 
   def fetch_dcid_by_coordinates(
       self,
@@ -159,7 +159,7 @@ class ResolveEndpoint(Endpoint):
                                                     to_type="dcid",
                                                     entity_type=entity_type)
     coordinates = f"{latitude}#{longitude}"
-    return self.fetch(node_dcids=coordinates, expression=expression)
+    return self.fetch(node_ids=coordinates, expression=expression)
 
   def fetch_entity_type_correspondence(
       self,
@@ -183,4 +183,4 @@ class ResolveEndpoint(Endpoint):
     expression = _resolve_correspondence_expression(from_type=from_type,
                                                     to_type=to_type,
                                                     entity_type=entity_type)
-    return self.fetch(node_dcids=entities, expression=expression)
+    return self.fetch(node_ids=entities, expression=expression)

--- a/datacommons_client/tests/endpoints/test_resolve_endpoint.py
+++ b/datacommons_client/tests/endpoints/test_resolve_endpoint.py
@@ -12,7 +12,7 @@ def test_fetch():
   api_mock = MagicMock(spec=API)
   endpoint = ResolveEndpoint(api=api_mock)
 
-  response = endpoint.fetch(node_dcids="Node1", expression="some_expression")
+  response = endpoint.fetch(node_ids="Node1", expression="some_expression")
 
   # Check the response
   assert isinstance(response, ResolveResponse)


### PR DESCRIPTION
Based on @kmoscoe's feedback, this PR improves clarity and coherence, rename `node_dcids`parameter to `node_ids`:

* Renamed `node_dcids` to `node_ids` in the `fetch` method and updated the corresponding payload construction.
* Updated method calls within the `fetch_dcids_by_name`, `fetch_dcid_by_wikidata_id`, `fetch_dcid_by_coordinates`, and `fetch_entity_type_correspondence` methods to use `node_ids` instead of `node_dcids`. [[1]](diffhunk://#diff-07b83f8a4db05288c8eb68d75253ca986efd73f49449d71a9574a7332e743ee8L105-R105) [[2]](diffhunk://#diff-07b83f8a4db05288c8eb68d75253ca986efd73f49449d71a9574a7332e743ee8L125-R125) [[3]](diffhunk://#diff-07b83f8a4db05288c8eb68d75253ca986efd73f49449d71a9574a7332e743ee8L162-R162) [[4]](diffhunk://#diff-07b83f8a4db05288c8eb68d75253ca986efd73f49449d71a9574a7332e743ee8L186-R186)

Updates to tests:

* Modified the `test_fetch` function in `test_resolve_endpoint.py` to use `node_ids` instead of `node_dcids` in the test case.