### PR TITLE
Remove `fetch_entity_type_correspondence`

### DIFF
--- a/datacommons_client/endpoints/resolve.py
+++ b/datacommons_client/endpoints/resolve.py
@@ -161,27 +161,3 @@ class ResolveEndpoint(Endpoint):
                                                     entity_type=entity_type)
     coordinates = f"{latitude}#{longitude}"
     return self.fetch(node_ids=coordinates, expression=expression)
-
-  def fetch_entity_type_correspondence(
-      self,
-      entities: str | list[str],
-      from_type: str,
-      to_type: str,
-      entity_type: str | None = None,
-  ) -> ResolveResponse:
-    """
-        Fetches the correspondence between entities of two types.
-
-        Args:
-            entities (str | list[str]): The entities to resolve.
-            from_type (str): The source entity type.
-            to_type (str): The target entity type.
-            entity_type (Optional[str]): Optional type of the entities.
-
-        Returns:
-            ResolveResponse: The response object containing the resolved correspondence.
-        """
-    expression = _resolve_correspondence_expression(from_type=from_type,
-                                                    to_type=to_type,
-                                                    entity_type=entity_type)
-    return self.fetch(node_ids=entities, expression=expression)

--- a/datacommons_client/tests/endpoints/test_resolve_endpoint.py
+++ b/datacommons_client/tests/endpoints/test_resolve_endpoint.py
@@ -91,30 +91,6 @@ def test_fetch_dcid_by_coordinates():
                                         next_token=None)
 
 
-def test_fetch_from_type_to_type():
-  """Tests the fetch_from_type_to_type method."""
-  # Mock the API
-  api_mock = MagicMock(spec=API)
-  endpoint = ResolveEndpoint(api=api_mock)
-
-  response = endpoint.fetch_entity_type_correspondence(entities="Node1",
-                                                       from_type="type1",
-                                                       to_type="type2",
-                                                       entity_type="Place")
-
-  # Check the response
-  assert isinstance(response, ResolveResponse)
-
-  # Check the post request
-  api_mock.post.assert_called_once_with(payload={
-      "nodes": ["Node1"],
-      "property": "<-type1{typeOf:Place}->type2",
-  },
-                                        endpoint="resolve",
-                                        all_pages=True,
-                                        next_token=None)
-
-
 def test_resolve_correspondence_expression():
   """Tests the resolve_correspondence_expression function."""
   expression = _resolve_correspondence_expression(from_type="description",


### PR DESCRIPTION
With thanks to @kmoscoe for figuring this out.

This method is of extremely limited utility (or perhaps none). I had missed the fact that “the expression must end with ->dcid”. Which means it’s impossible to create correspondence dictionaries to anything but dcids.
 
If there’s no way for the REST API to convert a dcid to a different type (say a wikiID) then there’s no real value for this method. This PR removes it.

If the REST API were capable of resolving something other than dcids in the future, we could reimplement this. In the meantime, all of this functionality is covered (in a clearer way) by other methods.