### PR TITLE
Add support for domain and facet filters

### DIFF
--- a/datacommons_client/client.py
+++ b/datacommons_client/client.py
@@ -99,13 +99,12 @@ class DataCommonsClient:
 
     if entity_dcids == "all":
       observations = self.observation.fetch_observations_by_entity_type(
-          variable_dcids=variable_dcids,
           date=date,
-          entity_type=entity_type,
           parent_entity=parent_entity,
-      )
+          entity_type=entity_type,
+          variable_dcids=variable_dcids)
     else:
       observations = self.observation.fetch_observations_by_entity(
-          variable_dcids=variable_dcids, date=date, entity_dcids=entity_dcids)
+          date=date, entity_dcids=entity_dcids, variable_dcids=variable_dcids)
 
     return pd.DataFrame(observations.get_observations_as_records())

--- a/datacommons_client/endpoints/observation.py
+++ b/datacommons_client/endpoints/observation.py
@@ -54,8 +54,8 @@ class ObservationEndpoint(Endpoint):
         select=select,
         entity_dcids=entity_dcids,
         entity_expression=entity_expression,
-        domains_filter=domains_filter,
-        facets_filter=facets_filter,
+        filter_facet_domains=domains_filter,
+        filter_facet_ids=facets_filter,
     ).to_dict
 
     # Send the request

--- a/datacommons_client/endpoints/observation.py
+++ b/datacommons_client/endpoints/observation.py
@@ -28,8 +28,9 @@ class ObservationEndpoint(Endpoint):
       select: Optional[list[ObservationSelect | str]] = None,
       entity_dcids: Optional[str | list[str]] = None,
       entity_expression: Optional[str] = None,
-      domains_filter: Optional[str | list[str]] = None,
-      facets_filter: Optional[str | list[str]] = None) -> ObservationResponse:
+      filter_facet_domains: Optional[str | list[str]] = None,
+      filter_facet_ids: Optional[str | list[str]] = None,
+  ) -> ObservationResponse:
     """
         Fetches data from the observation endpoint.
 
@@ -41,8 +42,8 @@ class ObservationEndpoint(Endpoint):
                 Defaults to ["date", "variable", "entity", "value"].
             entity_dcids (Optional[str | list[str]]): One or more entity IDs to filter the data.
             entity_expression (Optional[str]): A string expression to filter entities.
-            domains_filter (Optional[str | list[str]]): One or more domain names to filter the data.
-            facets_filter (Optional[str | list[str]]): One or more facet IDs to filter the data.
+            filter_facet_domains (Optional[str | list[str]]): One or more domain names to filter the data.
+            filter_facet_ids (Optional[str | list[str]]): One or more facet IDs to filter the data.
 
         Returns:
             ObservationResponse: The response object containing observations for the specified query.
@@ -54,8 +55,8 @@ class ObservationEndpoint(Endpoint):
         select=select,
         entity_dcids=entity_dcids,
         entity_expression=entity_expression,
-        filter_facet_domains=domains_filter,
-        filter_facet_ids=facets_filter,
+        filter_facet_domains=filter_facet_domains,
+        filter_facet_ids=filter_facet_ids,
     ).to_dict
 
     # Send the request
@@ -67,8 +68,8 @@ class ObservationEndpoint(Endpoint):
       entity_dcids: Optional[str | list[str]] = None,
       entity_expression: Optional[str] = None,
       *,
-      domains_filter: Optional[str | list[str]] = None,
-      facets_filter: Optional[str | list[str]] = None,
+      filter_facet_domains: Optional[str | list[str]] = None,
+      filter_facet_ids: Optional[str | list[str]] = None,
   ) -> ObservationResponse:
     """
         Fetches the latest observations for the given variable and entity.
@@ -77,43 +78,46 @@ class ObservationEndpoint(Endpoint):
             variable_dcids (str | list[str]): One or more variable IDs for the data.
             entity_dcids (Optional[str | list[str]]): One or more entity IDs to filter the data.
             entity_expression (Optional[str]): A string expression to filter entities.
-            domains_filter: Optional[str | list[str]: One or more domain names to filter the data.
-            facets_filter: Optional[str | list[str]: One or more facet IDs to filter the data.
+            filter_facet_domains: Optional[str | list[str]: One or more domain names to filter the data.
+            filter_facet_ids: Optional[str | list[str]: One or more facet IDs to filter the data.
 
         Returns:
             ObservationResponse: The response object containing observations for the specified query.
         """
-    return self.fetch(variable_dcids=variable_dcids,
-                      date=ObservationDate.LATEST,
-                      entity_dcids=entity_dcids,
-                      entity_expression=entity_expression,
-                      domains_filter=domains_filter,
-                      facets_filter=facets_filter)
+    return self.fetch(
+        variable_dcids=variable_dcids,
+        date=ObservationDate.LATEST,
+        entity_dcids=entity_dcids,
+        entity_expression=entity_expression,
+        filter_facet_domains=filter_facet_domains,
+        filter_facet_ids=filter_facet_ids,
+    )
 
   def fetch_latest_observations_by_entity(
       self,
       variable_dcids: str | list[str],
       entity_dcids: str | list[str],
       *,
-      domains_filter: Optional[str | list[str]] = None,
-      facets_filter: Optional[str | list[str]] = None,
+      filter_facet_domains: Optional[str | list[str]] = None,
+      filter_facet_ids: Optional[str | list[str]] = None,
   ) -> ObservationResponse:
     """Fetches the latest observations for the given variable and entities.
 
         Args:
             variable_dcids (str | list[str]): One or more variable IDs for the data.
             entity_dcids (str | list[str]): One or more entity IDs to filter the data.
-            domains_filter: Optional[str | list[str]: One or more domain names to filter the data.
-            facets_filter: Optional[str | list[str]: One or more facet IDs to filter the data.
+            filter_facet_domains: Optional[str | list[str]: One or more domain names to filter the data.
+            filter_facet_ids: Optional[str | list[str]: One or more facet IDs to filter the data.
 
         Returns:
             ObservationResponse: The response object containing observations for the specified query.
         """
 
-    return self.fetch_latest_observations(variable_dcids=variable_dcids,
-                                          entity_dcids=entity_dcids,
-                                          domains_filter=domains_filter,
-                                          facets_filter=facets_filter)
+    return self.fetch_latest_observations(
+        variable_dcids=variable_dcids,
+        entity_dcids=entity_dcids,
+        filter_facet_domains=filter_facet_domains,
+        filter_facet_ids=filter_facet_ids)
 
   def fetch_observations_by_entity_type(
       self,
@@ -122,8 +126,8 @@ class ObservationEndpoint(Endpoint):
       entity_type: str,
       variable_dcids: str | list[str],
       *,
-      domains_filter: Optional[str | list[str]] = None,
-      facets_filter: Optional[str | list[str]] = None,
+      filter_facet_domains: Optional[str | list[str]] = None,
+      filter_facet_ids: Optional[str | list[str]] = None,
   ) -> ObservationResponse:
     """
         Fetches all observations for a given entity type.
@@ -138,8 +142,8 @@ class ObservationEndpoint(Endpoint):
                 For example, "Country" or "Region".
             variable_dcids (str | list[str]): The variable(s) to fetch observations for.
                 This can be a single variable ID or a list of IDs.
-            domains_filter: Optional[str | list[str]: One or more domain names to filter the data.
-            facets_filter: Optional[str | list[str]: One or more facet IDs to filter the data.
+            filter_facet_domains: Optional[str | list[str]: One or more domain names to filter the data.
+            filter_facet_ids: Optional[str | list[str]: One or more facet IDs to filter the data.
 
         Returns:
             ObservationResponse: The response object containing observations for the specified entity type.
@@ -164,8 +168,8 @@ class ObservationEndpoint(Endpoint):
         select=[s for s in ObservationSelect],
         entity_expression=
         f"{parent_entity}<-containedInPlace+{{typeOf:{entity_type}}}",
-        domains_filter=domains_filter,
-        facets_filter=facets_filter,
+        filter_facet_domains=filter_facet_domains,
+        filter_facet_ids=filter_facet_ids,
     )
 
   def fetch_observations_by_entity(
@@ -174,8 +178,8 @@ class ObservationEndpoint(Endpoint):
       entity_dcids: str | list[str],
       variable_dcids: str | list[str],
       *,
-      domains_filter: Optional[str | list[str]] = None,
-      facets_filter: Optional[str | list[str]] = None,
+      filter_facet_domains: Optional[str | list[str]] = None,
+      filter_facet_ids: Optional[str | list[str]] = None,
   ) -> ObservationResponse:
     """
         Fetches all observations for a given entity type.
@@ -187,8 +191,8 @@ class ObservationEndpoint(Endpoint):
             entity_dcids (str | list[str]): One or more entity IDs to filter the data.
             variable_dcids (str | list[str]): The variable(s) to fetch observations for.
                 This can be a single variable ID or a list of IDs.
-            domains_filter: Optional[str | list[str]: One or more domain names to filter the data.
-            facets_filter: Optional[str | list[str]: One or more facet IDs to filter the data.
+            filter_facet_domains: Optional[str | list[str]: One or more domain names to filter the data.
+            filter_facet_ids: Optional[str | list[str]: One or more facet IDs to filter the data.
 
         Returns:
             ObservationResponse: The response object containing observations for the specified entity type.
@@ -209,8 +213,8 @@ class ObservationEndpoint(Endpoint):
     return self.fetch(
         variable_dcids=variable_dcids,
         date=date,
-        entity_dcids=entity_dcids,
         select=[s for s in ObservationSelect],
-        domains_filter=domains_filter,
-        facets_filter=facets_filter,
+        entity_dcids=entity_dcids,
+        filter_facet_domains=filter_facet_domains,
+        filter_facet_ids=filter_facet_ids,
     )

--- a/datacommons_client/endpoints/observation.py
+++ b/datacommons_client/endpoints/observation.py
@@ -66,6 +66,9 @@ class ObservationEndpoint(Endpoint):
       variable_dcids: str | list[str],
       entity_dcids: Optional[str | list[str]] = None,
       entity_expression: Optional[str] = None,
+      *,
+      domains_filter: Optional[str | list[str]] = None,
+      facets_filter: Optional[str | list[str]] = None,
   ) -> ObservationResponse:
     """
         Fetches the latest observations for the given variable and entity.
@@ -74,34 +77,43 @@ class ObservationEndpoint(Endpoint):
             variable_dcids (str | list[str]): One or more variable IDs for the data.
             entity_dcids (Optional[str | list[str]]): One or more entity IDs to filter the data.
             entity_expression (Optional[str]): A string expression to filter entities.
+            domains_filter: Optional[str | list[str]: One or more domain names to filter the data.
+            facets_filter: Optional[str | list[str]: One or more facet IDs to filter the data.
 
         Returns:
             ObservationResponse: The response object containing observations for the specified query.
         """
-    return self.fetch(
-        variable_dcids=variable_dcids,
-        date=ObservationDate.LATEST,
-        entity_dcids=entity_dcids,
-        entity_expression=entity_expression,
-    )
+    return self.fetch(variable_dcids=variable_dcids,
+                      date=ObservationDate.LATEST,
+                      entity_dcids=entity_dcids,
+                      entity_expression=entity_expression,
+                      domains_filter=domains_filter,
+                      facets_filter=facets_filter)
 
   def fetch_latest_observations_by_entity(
       self,
       variable_dcids: str | list[str],
       entity_dcids: str | list[str],
+      *,
+      domains_filter: Optional[str | list[str]] = None,
+      facets_filter: Optional[str | list[str]] = None,
   ) -> ObservationResponse:
     """Fetches the latest observations for the given variable and entities.
 
         Args:
             variable_dcids (str | list[str]): One or more variable IDs for the data.
             entity_dcids (str | list[str]): One or more entity IDs to filter the data.
+            domains_filter: Optional[str | list[str]: One or more domain names to filter the data.
+            facets_filter: Optional[str | list[str]: One or more facet IDs to filter the data.
 
         Returns:
             ObservationResponse: The response object containing observations for the specified query.
         """
 
     return self.fetch_latest_observations(variable_dcids=variable_dcids,
-                                          entity_dcids=entity_dcids)
+                                          entity_dcids=entity_dcids,
+                                          domains_filter=domains_filter,
+                                          facets_filter=facets_filter)
 
   def fetch_observations_by_entity_type(
       self,
@@ -109,6 +121,9 @@ class ObservationEndpoint(Endpoint):
       parent_entity: str,
       entity_type: str,
       variable_dcids: str | list[str],
+      *,
+      domains_filter: Optional[str | list[str]] = None,
+      facets_filter: Optional[str | list[str]] = None,
   ) -> ObservationResponse:
     """
         Fetches all observations for a given entity type.
@@ -123,6 +138,8 @@ class ObservationEndpoint(Endpoint):
                 For example, "Country" or "Region".
             variable_dcids (str | list[str]): The variable(s) to fetch observations for.
                 This can be a single variable ID or a list of IDs.
+            domains_filter: Optional[str | list[str]: One or more domain names to filter the data.
+            facets_filter: Optional[str | list[str]: One or more facet IDs to filter the data.
 
         Returns:
             ObservationResponse: The response object containing observations for the specified entity type.
@@ -147,6 +164,8 @@ class ObservationEndpoint(Endpoint):
         select=[s for s in ObservationSelect],
         entity_expression=
         f"{parent_entity}<-containedInPlace+{{typeOf:{entity_type}}}",
+        domains_filter=domains_filter,
+        facets_filter=facets_filter,
     )
 
   def fetch_observations_by_entity(
@@ -154,6 +173,9 @@ class ObservationEndpoint(Endpoint):
       date: ObservationDate | str,
       entity_dcids: str | list[str],
       variable_dcids: str | list[str],
+      *,
+      domains_filter: Optional[str | list[str]] = None,
+      facets_filter: Optional[str | list[str]] = None,
   ) -> ObservationResponse:
     """
         Fetches all observations for a given entity type.
@@ -165,6 +187,8 @@ class ObservationEndpoint(Endpoint):
             entity_dcids (str | list[str]): One or more entity IDs to filter the data.
             variable_dcids (str | list[str]): The variable(s) to fetch observations for.
                 This can be a single variable ID or a list of IDs.
+            domains_filter: Optional[str | list[str]: One or more domain names to filter the data.
+            facets_filter: Optional[str | list[str]: One or more facet IDs to filter the data.
 
         Returns:
             ObservationResponse: The response object containing observations for the specified entity type.
@@ -187,4 +211,6 @@ class ObservationEndpoint(Endpoint):
         date=date,
         entity_dcids=entity_dcids,
         select=[s for s in ObservationSelect],
+        domains_filter=domains_filter,
+        facets_filter=facets_filter,
     )

--- a/datacommons_client/endpoints/observation.py
+++ b/datacommons_client/endpoints/observation.py
@@ -28,7 +28,8 @@ class ObservationEndpoint(Endpoint):
       select: Optional[list[ObservationSelect | str]] = None,
       entity_dcids: Optional[str | list[str]] = None,
       entity_expression: Optional[str] = None,
-  ) -> ObservationResponse:
+      domains_filter: Optional[str | list[str]] = None,
+      facets_filter: Optional[str | list[str]] = None) -> ObservationResponse:
     """
         Fetches data from the observation endpoint.
 
@@ -40,6 +41,8 @@ class ObservationEndpoint(Endpoint):
                 Defaults to ["date", "variable", "entity", "value"].
             entity_dcids (Optional[str | list[str]]): One or more entity IDs to filter the data.
             entity_expression (Optional[str]): A string expression to filter entities.
+            domains_filter (Optional[str | list[str]]): One or more domain names to filter the data.
+            facets_filter (Optional[str | list[str]]): One or more facet IDs to filter the data.
 
         Returns:
             ObservationResponse: The response object containing observations for the specified query.
@@ -51,6 +54,8 @@ class ObservationEndpoint(Endpoint):
         select=select,
         entity_dcids=entity_dcids,
         entity_expression=entity_expression,
+        domains_filter=domains_filter,
+        facets_filter=facets_filter,
     ).to_dict
 
     # Send the request

--- a/datacommons_client/endpoints/payloads.py
+++ b/datacommons_client/endpoints/payloads.py
@@ -104,8 +104,8 @@ class ObservationRequestPayload(EndpointRequestPayload):
             Defaults to ["date", "variable", "entity", "value"].
         entity_dcids (Optional[str | list[str]]): One or more entity IDs to filter the data.
         entity_expression (Optional[str]): A string expression to filter entities.
-        domains_filter (Optional[str | list[str]]): One or more domain names to filter the data.
-        facets_filter (Optional[str | list[str]]): One or more facet IDs to filter the data.
+        filter_facet_domains (Optional[str | list[str]]): One or more domain names to filter the data.
+        filter_facet_ids (Optional[str | list[str]]): One or more facet IDs to filter the data.
     """
 
   date: ObservationDate | str = ""
@@ -113,8 +113,8 @@ class ObservationRequestPayload(EndpointRequestPayload):
   select: Optional[list[ObservationSelect | str]] = None
   entity_dcids: Optional[str | list[str]] = None
   entity_expression: Optional[str] = None
-  domains_filter: Optional[str | list[str]] = None
-  facets_filter: Optional[str | list[str]] = None
+  filter_facet_domains: Optional[str | list[str]] = None
+  filter_facet_ids: Optional[str | list[str]] = None
 
   def __post_init__(self):
     """
@@ -139,7 +139,7 @@ class ObservationRequestPayload(EndpointRequestPayload):
     """
         Normalizes the payload for consistent internal representation.
 
-        - Converts `variable_dcids`, `entity_dcids`, `domains_filter` and `facets_filter`
+        - Converts `variable_dcids`, `entity_dcids`, `filter_facet_domains` and `filter_facet_ids`
          to lists if they are passed as strings.
         - Normalizes the `date` field to ensure it is in the correct format.
         """
@@ -157,13 +157,13 @@ class ObservationRequestPayload(EndpointRequestPayload):
     elif (self.date.upper() == "LATEST") or (self.date == ""):
       self.date = ObservationDate.LATEST
 
-    # Normalize domains_filter
-    if isinstance(self.domains_filter, str):
-      self.domains_filter = [self.domains_filter]
+    # Normalize filter_facet_domains
+    if isinstance(self.filter_facet_domains, str):
+      self.filter_facet_domains = [self.filter_facet_domains]
 
-    # Normalize facets_filter
-    if isinstance(self.facets_filter, str):
-      self.facets_filter = [self.facets_filter]
+    # Normalize filter_facet_ids
+    if isinstance(self.filter_facet_ids, str):
+      self.filter_facet_ids = [self.filter_facet_ids]
 
   def validate(self):
     """
@@ -215,8 +215,8 @@ class ObservationRequestPayload(EndpointRequestPayload):
     # Create a filter dictionary with only non-empty values
     filters = {
         k: v for k, v in {
-            "domains": self.domains_filter,
-            "facet_ids": self.facets_filter,
+            "domains": self.filter_facet_domains,
+            "facet_ids": self.filter_facet_ids,
         }.items() if v
     }
 

--- a/datacommons_client/tests/endpoints/test_observation_endpoint.py
+++ b/datacommons_client/tests/endpoints/test_observation_endpoint.py
@@ -16,6 +16,8 @@ def test_fetch():
       date=ObservationDate.LATEST,
       select=["date", "variable", "entity", "value"],
       entity_dcids="dc/EntityID",
+      domains_filter="domain1",
+      facets_filter="facet1",
   )
 
   # Check the response
@@ -31,6 +33,10 @@ def test_fetch():
           "dcids": ["dc/EntityID"],
       },
       "select": ["date", "variable", "entity", "value"],
+      "filter": {
+          "domains": ["domain1"],
+          "facet_ids": ["facet1"]
+      }
   },
                                         endpoint="observation",
                                         all_pages=True,

--- a/datacommons_client/tests/endpoints/test_observation_endpoint.py
+++ b/datacommons_client/tests/endpoints/test_observation_endpoint.py
@@ -80,6 +80,7 @@ def test_fetch_latest_observations_by_entity():
   response = endpoint.fetch_latest_observations_by_entity(
       variable_dcids="dc/VariableID",
       entity_dcids=["dc/Entity1", "dc/Entity2"],
+      facets_filter="facet1",
   )
 
   # Check the response
@@ -95,6 +96,9 @@ def test_fetch_latest_observations_by_entity():
           "dcids": ["dc/Entity1", "dc/Entity2"]
       },
       "select": ["date", "variable", "entity", "value"],
+      "filter": {
+          "facet_ids": ["facet1"]
+      }
   },
                                         endpoint="observation",
                                         all_pages=True,

--- a/datacommons_client/tests/endpoints/test_observation_endpoint.py
+++ b/datacommons_client/tests/endpoints/test_observation_endpoint.py
@@ -11,14 +11,12 @@ def test_fetch():
   api_mock = MagicMock(spec=API)
   endpoint = ObservationEndpoint(api=api_mock)
 
-  response = endpoint.fetch(
-      variable_dcids="dcid/variableID",
-      date=ObservationDate.LATEST,
-      select=["date", "variable", "entity", "value"],
-      entity_dcids="dc/EntityID",
-      domains_filter="domain1",
-      facets_filter="facet1",
-  )
+  response = endpoint.fetch(variable_dcids="dcid/variableID",
+                            date=ObservationDate.LATEST,
+                            select=["date", "variable", "entity", "value"],
+                            entity_dcids="dc/EntityID",
+                            filter_facet_domains="domain1",
+                            filter_facet_ids="facet1")
 
   # Check the response
   assert isinstance(response, ObservationResponse)
@@ -80,8 +78,7 @@ def test_fetch_latest_observations_by_entity():
   response = endpoint.fetch_latest_observations_by_entity(
       variable_dcids="dc/VariableID",
       entity_dcids=["dc/Entity1", "dc/Entity2"],
-      facets_filter="facet1",
-  )
+      filter_facet_ids="facet1")
 
   # Check the response
   assert isinstance(response, ObservationResponse)
@@ -114,8 +111,7 @@ def test_fetch_observations_by_entity_type():
       date="2023",
       parent_entity="Earth",
       entity_type="Country",
-      variable_dcids="dc/VariableID",
-  )
+      variable_dcids="dc/VariableID")
 
   # Check the response
   assert isinstance(response, ObservationResponse)

--- a/datacommons_client/tests/endpoints/test_payloads.py
+++ b/datacommons_client/tests/endpoints/test_payloads.py
@@ -38,11 +38,20 @@ def test_observation_payload_normalize():
       variable_dcids="var1",
       select=["variable", "entity"],
       entity_dcids="ent1",
+      domains_filter="domain1",
+      facets_filter="facets1",
   )
   assert payload.variable_dcids == ["var1"]
   assert payload.entity_dcids == ["ent1"]
+  assert payload.domains_filter == ["domain1"]
+  assert payload.facets_filter == ["facets1"]
   assert payload.date == ObservationDate.LATEST
 
+  assert "filter" in payload.to_dict
+  assert "facet_ids" in payload.to_dict["filter"]
+  assert "domains" in payload.to_dict["filter"]
+
+  # Check that when domain and facets are not included, they are not in the payload
   payload = ObservationRequestPayload(
       date="all",
       variable_dcids=["var1"],
@@ -52,6 +61,7 @@ def test_observation_payload_normalize():
   assert payload.date == ObservationDate.ALL
   assert payload.variable_dcids == ["var1"]
   assert payload.entity_dcids == ["ent1"]
+  assert "filter" not in payload.to_dict
 
 
 def test_observation_select_invalid_value():
@@ -101,6 +111,7 @@ def test_observation_payload_to_dict():
       variable_dcids="var1",
       select=["variable", "entity"],
       entity_dcids="ent1",
+      facets_filter="facets1",
   )
   assert payload.to_dict == {
       "date": ObservationDate.LATEST,
@@ -111,6 +122,9 @@ def test_observation_payload_to_dict():
           "dcids": ["ent1"]
       },
       "select": ["variable", "entity"],
+      "filter": {
+          "facet_ids": ["facets1"]
+      }
   }
 
 

--- a/datacommons_client/tests/endpoints/test_payloads.py
+++ b/datacommons_client/tests/endpoints/test_payloads.py
@@ -38,13 +38,13 @@ def test_observation_payload_normalize():
       variable_dcids="var1",
       select=["variable", "entity"],
       entity_dcids="ent1",
-      domains_filter="domain1",
-      facets_filter="facets1",
+      filter_facet_domains="domain1",
+      filter_facet_ids="facets1",
   )
   assert payload.variable_dcids == ["var1"]
   assert payload.entity_dcids == ["ent1"]
-  assert payload.domains_filter == ["domain1"]
-  assert payload.facets_filter == ["facets1"]
+  assert payload.filter_facet_domains == ["domain1"]
+  assert payload.filter_facet_ids == ["facets1"]
   assert payload.date == ObservationDate.LATEST
 
   assert "filter" in payload.to_dict
@@ -111,7 +111,7 @@ def test_observation_payload_to_dict():
       variable_dcids="var1",
       select=["variable", "entity"],
       entity_dcids="ent1",
-      facets_filter="facets1",
+      filter_facet_ids="facets1",
   )
   assert payload.to_dict == {
       "date": ObservationDate.LATEST,


### PR DESCRIPTION
This PR adds support for the domains and facets filters for the Observations endpoint. These filters were recently documented by @kmoscoe.

The filters are implemented as additional parameters for the `ObservationEndpoint`:
```python
domains_filter: Optional[str | list[str]] = None
facets_filter: Optional[str | list[str]] = None
```
They are used when building the payload via the `ObservationRequestPayload`. The payload will add a "filter" key with the right contents if either `domains_filter` or `facets_filter` is used.

From a user point of view, this PR will enable this type of queries

```python
from datacommons_client import DataCommonsClient

# Create a DataCommonsClient object
dc = DataCommonsClient(dc_instance="datacommons.one.org")

response_with_facet_filter = dc.observation.fetch(
    variable_dcids="Count_Person",
    entity_dcids="country/USA",
    date="latest",
    facets_filter="1145703171"
)

response_with_domain_filter = dc.observation.fetch(
    variable_dcids="Count_Person",
    entity_dcids="country/USA",
    date="latest",
    domains_filter="www2.census.gov"
)
```

The PR also modifies existing tests to correctly test cases where these two new filters are used.

