### PR TITLE
feature: support property filters in `observations_dataframe` 

### DIFF
--- a/datacommons_client/client.py
+++ b/datacommons_client/client.py
@@ -6,6 +6,7 @@ from datacommons_client.endpoints.observation import ObservationEndpoint
 from datacommons_client.endpoints.payloads import ObservationDate
 from datacommons_client.endpoints.resolve import ResolveEndpoint
 from datacommons_client.utils.decorators import requires_pandas
+from datacommons_client.utils.error_handling import NoDataForPropertyError
 
 try:
   import pandas as pd
@@ -58,6 +59,58 @@ class DataCommonsClient:
     self.observation = ObservationEndpoint(api=self.api)
     self.resolve = ResolveEndpoint(api=self.api)
 
+  def _find_filter_facet_ids(
+      self,
+      fetch_by: Literal["entity", "entity_type"],
+      date: ObservationDate | str,
+      variable_dcids: str | list[str],
+      entity_dcids: Literal["all"] | list[str] = "all",
+      entity_type: Optional[str] = None,
+      parent_entity: Optional[str] = None,
+      property_filters: Optional[dict] = None,
+  ) -> list[str] | None:
+    """Finds matching facet IDs for property filters.
+
+        Args:
+            fetch_by (Literal["entity", "entity_type"]): Determines whether to fetch by entity or entity type.
+            variable_dcids (str | list[str]): The variable DCIDs for which to retrieve facet IDs.
+            entity_dcids (Literal["all"] | list[str], optional): The entity DCIDs, or "all" if filtering by entity type.
+            entity_type (Optional[str], optional): The entity type, required if fetching by entity type.
+            parent_entity (Optional[str], optional): The parent entity, used when fetching by entity type.
+            property_filters (Optional[dict], optional): A dictionary of properties to match facets against.
+
+        Returns:
+            list[str] | None: A list of matching facet IDs, or None if no filters are applied.
+        """
+
+    if not property_filters:
+      return None
+
+    if fetch_by == "entity":
+      observations = self.observation.fetch_observations_by_entity(
+          date=date,
+          entity_dcids=entity_dcids,
+          variable_dcids=variable_dcids,
+          select=["variable", "entity", "facet"],
+      )
+    else:
+      observations = self.observation.fetch_observations_by_entity_type(
+          date=date,
+          entity_type=entity_type,
+          parent_entity=parent_entity,
+          variable_dcids=variable_dcids,
+          select=["variable", "entity", "facet"],
+      )
+
+    facet_sets = [
+        observations.find_matching_facet_id(property_name=p, value=v)
+        for p, v in property_filters.items()
+    ]
+
+    facet_ids = list({facet for facets in facet_sets for facet in facets})
+
+    return facet_ids
+
   @requires_pandas
   def observations_dataframe(
       self,
@@ -66,6 +119,7 @@ class DataCommonsClient:
       entity_dcids: Literal["all"] | list[str] = "all",
       entity_type: Optional[str] = None,
       parent_entity: Optional[str] = None,
+      property_filters: Optional[dict] = None,
   ):
     """
         Fetches statistical observations and returns them as a Pandas DataFrame.
@@ -74,15 +128,17 @@ class DataCommonsClient:
         at a particular date (e.g., "population of USA in 2020", "GDP of California in 2010").
 
         Args:
-            variable_dcids (str | list[str]): One or more variable DCIDs for the observation.
-            date (ObservationDate | str): The date for which observations are requested. It can be
+        variable_dcids (str | list[str]): One or more variable DCIDs for the observation.
+        date (ObservationDate | str): The date for which observations are requested. It can be
             a specific date, "all" to retrieve all observations, or "latest" to get the most recent observations.
-            entity_dcids (Literal["all"] | list[str], optional): The entity DCIDs to retrieve data for.
-                Defaults to "all". DCIDs must include their type (e.g "country/GTM" for Guatemala).
-            entity_type (Optional[str], optional): The type of entities to filter by when `entity_dcids="all"`.
-                Required if `entity_dcids="all"`. Defaults to None.
-            parent_entity (Optional[str], optional): The parent entity under which the target entities fall.
-                Used only when `entity_dcids="all"`. Defaults to None.
+        entity_dcids (Literal["all"] | list[str], optional): The entity DCIDs to retrieve data for.
+            Defaults to "all". DCIDs must include their type (e.g., "country/GTM" for Guatemala).
+        entity_type (Optional[str], optional): The type of entities to filter by when `entity_dcids="all"`.
+            Required if `entity_dcids="all"`. Defaults to None.
+        parent_entity (Optional[str], optional): The parent entity under which the target entities fall.
+            Used only when `entity_dcids="all"`. Defaults to None.
+        property_filters (Optional[dict], optional): An optional dictionary used to filter the data using
+            properties like `measurementMethod`, `unit`, or `observationPeriod`.
 
         Returns:
             pd.DataFrame: A DataFrame containing the requested observations.
@@ -97,14 +153,34 @@ class DataCommonsClient:
           "Specify 'entity_type' and 'parent_entity' only when 'entity_dcids' is 'all'."
       )
 
+    # If property filters are provided, fetch the required facet IDs. Otherwise, set to None.
+    facets = self._find_filter_facet_ids(
+        fetch_by="entity" if entity_dcids != "all" else "entity_type",
+        date=date,
+        variable_dcids=variable_dcids,
+        entity_dcids=entity_dcids,
+        entity_type=entity_type,
+        parent_entity=parent_entity,
+        property_filters=property_filters,
+    )
+
+    if not facets and property_filters:
+      raise NoDataForPropertyError
+
     if entity_dcids == "all":
       observations = self.observation.fetch_observations_by_entity_type(
           date=date,
           parent_entity=parent_entity,
           entity_type=entity_type,
-          variable_dcids=variable_dcids)
+          variable_dcids=variable_dcids,
+          filter_facet_ids=facets,
+      )
     else:
       observations = self.observation.fetch_observations_by_entity(
-          date=date, entity_dcids=entity_dcids, variable_dcids=variable_dcids)
+          date=date,
+          entity_dcids=entity_dcids,
+          variable_dcids=variable_dcids,
+          filter_facet_ids=facets,
+      )
 
     return pd.DataFrame(observations.get_observations_as_records())

--- a/datacommons_client/client.py
+++ b/datacommons_client/client.py
@@ -67,7 +67,7 @@ class DataCommonsClient:
       entity_dcids: Literal["all"] | list[str] = "all",
       entity_type: Optional[str] = None,
       parent_entity: Optional[str] = None,
-      property_filters: Optional[dict] = None,
+      property_filters: Optional[dict[str, str | list[str]]] = None,
   ) -> list[str] | None:
     """Finds matching facet IDs for property filters.
 
@@ -75,9 +75,9 @@ class DataCommonsClient:
             fetch_by (Literal["entity", "entity_type"]): Determines whether to fetch by entity or entity type.
             variable_dcids (str | list[str]): The variable DCIDs for which to retrieve facet IDs.
             entity_dcids (Literal["all"] | list[str], optional): The entity DCIDs, or "all" if filtering by entity type.
-            entity_type (Optional[str], optional): The entity type, required if fetching by entity type.
-            parent_entity (Optional[str], optional): The parent entity, used when fetching by entity type.
-            property_filters (Optional[dict], optional): A dictionary of properties to match facets against.
+            entity_type (Optional[str]): The entity type, required if fetching by entity type.
+            parent_entity (Optional[str]): The parent entity, used when fetching by entity type.
+            property_filters (Optional[dict[str, str | list[str]]): A dictionary of properties to match facets against.
 
         Returns:
             list[str] | None: A list of matching facet IDs, or None if no filters are applied.
@@ -119,7 +119,7 @@ class DataCommonsClient:
       entity_dcids: Literal["all"] | list[str] = "all",
       entity_type: Optional[str] = None,
       parent_entity: Optional[str] = None,
-      property_filters: Optional[dict] = None,
+      property_filters: Optional[dict[str, str | list[str]]] = None,
   ):
     """
         Fetches statistical observations and returns them as a Pandas DataFrame.
@@ -133,12 +133,12 @@ class DataCommonsClient:
             a specific date, "all" to retrieve all observations, or "latest" to get the most recent observations.
         entity_dcids (Literal["all"] | list[str], optional): The entity DCIDs to retrieve data for.
             Defaults to "all". DCIDs must include their type (e.g., "country/GTM" for Guatemala).
-        entity_type (Optional[str], optional): The type of entities to filter by when `entity_dcids="all"`.
+        entity_type (Optional[str]): The type of entities to filter by when `entity_dcids="all"`.
             Required if `entity_dcids="all"`. Defaults to None.
-        parent_entity (Optional[str], optional): The parent entity under which the target entities fall.
+        parent_entity (Optional[str]): The parent entity under which the target entities fall.
             Used only when `entity_dcids="all"`. Defaults to None.
-        property_filters (Optional[dict], optional): An optional dictionary used to filter the data using
-            properties like `measurementMethod`, `unit`, or `observationPeriod`.
+        property_filters (Optional[dict[str, str | list[str]]): An optional dictionary used to filter
+            the data by using observation properties like `measurementMethod`, `unit`, or `observationPeriod`.
 
         Returns:
             pd.DataFrame: A DataFrame containing the requested observations.

--- a/datacommons_client/endpoints/observation.py
+++ b/datacommons_client/endpoints/observation.py
@@ -68,6 +68,7 @@ class ObservationEndpoint(Endpoint):
       entity_dcids: Optional[str | list[str]] = None,
       entity_expression: Optional[str] = None,
       *,
+      select: Optional[list[ObservationSelect | str]] = None,
       filter_facet_domains: Optional[str | list[str]] = None,
       filter_facet_ids: Optional[str | list[str]] = None,
   ) -> ObservationResponse:
@@ -78,6 +79,8 @@ class ObservationEndpoint(Endpoint):
             variable_dcids (str | list[str]): One or more variable IDs for the data.
             entity_dcids (Optional[str | list[str]]): One or more entity IDs to filter the data.
             entity_expression (Optional[str]): A string expression to filter entities.
+            select (Optional[list[ObservationSelect | str]]): Fields to include in the response.
+                If not provided, defaults to ["date", "variable", "entity", "value"].
             filter_facet_domains: Optional[str | list[str]: One or more domain names to filter the data.
             filter_facet_ids: Optional[str | list[str]: One or more facet IDs to filter the data.
 
@@ -91,6 +94,7 @@ class ObservationEndpoint(Endpoint):
         entity_expression=entity_expression,
         filter_facet_domains=filter_facet_domains,
         filter_facet_ids=filter_facet_ids,
+        select=[s for s in ObservationSelect] if not select else select,
     )
 
   def fetch_latest_observations_by_entity(
@@ -98,6 +102,7 @@ class ObservationEndpoint(Endpoint):
       variable_dcids: str | list[str],
       entity_dcids: str | list[str],
       *,
+      select: Optional[list[ObservationSelect | str]] = None,
       filter_facet_domains: Optional[str | list[str]] = None,
       filter_facet_ids: Optional[str | list[str]] = None,
   ) -> ObservationResponse:
@@ -106,6 +111,8 @@ class ObservationEndpoint(Endpoint):
         Args:
             variable_dcids (str | list[str]): One or more variable IDs for the data.
             entity_dcids (str | list[str]): One or more entity IDs to filter the data.
+            select (Optional[list[ObservationSelect | str]]): Fields to include in the response.
+                If not provided, defaults to ["date", "variable", "entity", "value"].
             filter_facet_domains: Optional[str | list[str]: One or more domain names to filter the data.
             filter_facet_ids: Optional[str | list[str]: One or more facet IDs to filter the data.
 
@@ -116,8 +123,10 @@ class ObservationEndpoint(Endpoint):
     return self.fetch_latest_observations(
         variable_dcids=variable_dcids,
         entity_dcids=entity_dcids,
+        select=[s for s in ObservationSelect] if not select else select,
         filter_facet_domains=filter_facet_domains,
-        filter_facet_ids=filter_facet_ids)
+        filter_facet_ids=filter_facet_ids,
+    )
 
   def fetch_observations_by_entity_type(
       self,
@@ -126,6 +135,7 @@ class ObservationEndpoint(Endpoint):
       entity_type: str,
       variable_dcids: str | list[str],
       *,
+      select: Optional[list[ObservationSelect | str]] = None,
       filter_facet_domains: Optional[str | list[str]] = None,
       filter_facet_ids: Optional[str | list[str]] = None,
   ) -> ObservationResponse:
@@ -142,6 +152,8 @@ class ObservationEndpoint(Endpoint):
                 For example, "Country" or "Region".
             variable_dcids (str | list[str]): The variable(s) to fetch observations for.
                 This can be a single variable ID or a list of IDs.
+            select (Optional[list[ObservationSelect | str]]): Fields to include in the response.
+                If not provided, defaults to ["date", "variable", "entity", "value"].
             filter_facet_domains: Optional[str | list[str]: One or more domain names to filter the data.
             filter_facet_ids: Optional[str | list[str]: One or more facet IDs to filter the data.
 
@@ -165,7 +177,7 @@ class ObservationEndpoint(Endpoint):
     return self.fetch(
         variable_dcids=variable_dcids,
         date=date,
-        select=[s for s in ObservationSelect],
+        select=[s for s in ObservationSelect] if not select else select,
         entity_expression=
         f"{parent_entity}<-containedInPlace+{{typeOf:{entity_type}}}",
         filter_facet_domains=filter_facet_domains,
@@ -178,6 +190,7 @@ class ObservationEndpoint(Endpoint):
       entity_dcids: str | list[str],
       variable_dcids: str | list[str],
       *,
+      select: Optional[list[ObservationSelect | str]] = None,
       filter_facet_domains: Optional[str | list[str]] = None,
       filter_facet_ids: Optional[str | list[str]] = None,
   ) -> ObservationResponse:
@@ -191,6 +204,8 @@ class ObservationEndpoint(Endpoint):
             entity_dcids (str | list[str]): One or more entity IDs to filter the data.
             variable_dcids (str | list[str]): The variable(s) to fetch observations for.
                 This can be a single variable ID or a list of IDs.
+            select (Optional[list[ObservationSelect | str]]): Fields to include in the response.
+                If not provided, defaults to ["date", "variable", "entity", "value"].
             filter_facet_domains: Optional[str | list[str]: One or more domain names to filter the data.
             filter_facet_ids: Optional[str | list[str]: One or more facet IDs to filter the data.
 
@@ -213,7 +228,7 @@ class ObservationEndpoint(Endpoint):
     return self.fetch(
         variable_dcids=variable_dcids,
         date=date,
-        select=[s for s in ObservationSelect],
+        select=[s for s in ObservationSelect] if not select else select,
         entity_dcids=entity_dcids,
         filter_facet_domains=filter_facet_domains,
         filter_facet_ids=filter_facet_ids,

--- a/datacommons_client/endpoints/payloads.py
+++ b/datacommons_client/endpoints/payloads.py
@@ -78,6 +78,7 @@ class ObservationSelect(str, Enum):
   VARIABLE = "variable"
   ENTITY = "entity"
   VALUE = "value"
+  FACET = "facet"
 
   @classmethod
   def _missing_(cls, value):

--- a/datacommons_client/endpoints/payloads.py
+++ b/datacommons_client/endpoints/payloads.py
@@ -138,8 +138,6 @@ class ObservationRequestPayload(EndpointRequestPayload):
   def normalize(self):
     """
         Normalizes the payload for consistent internal representation.
-
-
         - Converts `variable_dcids`, `entity_dcids`, `filter_facet_domains` and `filter_facet_ids`
          to lists if they are passed as strings.
         - Normalizes the `date` field to ensure it is in the correct format.

--- a/datacommons_client/endpoints/payloads.py
+++ b/datacommons_client/endpoints/payloads.py
@@ -139,6 +139,7 @@ class ObservationRequestPayload(EndpointRequestPayload):
     """
         Normalizes the payload for consistent internal representation.
 
+
         - Converts `variable_dcids`, `entity_dcids`, `filter_facet_domains` and `filter_facet_ids`
          to lists if they are passed as strings.
         - Normalizes the `date` field to ensure it is in the correct format.

--- a/datacommons_client/endpoints/response.py
+++ b/datacommons_client/endpoints/response.py
@@ -193,20 +193,21 @@ class ObservationResponse(SerializableMixin):
 
     return metadata
 
-  def find_matching_facet_id(self, property_name: str, value: str) -> list[str]:
+  def find_matching_facet_id(self, property_name: str,
+                             value: str | list[str]) -> list[str]:
     """Finds facet IDs that match a given property and value.
 
         Args:
             property_name (str): The property to match.
-            value (str): The value to match.
-
+            value (str | list): The value to match. Can be a string, number, or a list of values.
         Returns:
             list[str]: A list of facet IDs that match the property and value.
         """
     return [
         facet_id for facet_data in self.get_facets_metadata().values()
         for facet_id, metadata in facet_data.items()
-        if metadata.get(property_name) == value
+        if metadata.get(property_name) == value or
+        (isinstance(value, list) and metadata.get(property_name) in value)
     ]
 
 

--- a/datacommons_client/endpoints/response.py
+++ b/datacommons_client/endpoints/response.py
@@ -203,12 +203,26 @@ class ObservationResponse(SerializableMixin):
         Returns:
             list[str]: A list of facet IDs that match the property and value.
         """
-    return [
-        facet_id for facet_data in self.get_facets_metadata().values()
-        for facet_id, metadata in facet_data.items()
-        if metadata.get(property_name) == value or
-        (isinstance(value, list) and metadata.get(property_name) in value)
-    ]
+    # Initialize an empty list to store matching facet IDs
+    matching_facet_ids = []
+
+    # Iterate over the facets metadata to find matching facet IDs
+    for facet_data in self.get_facets_metadata().values():
+
+      # Iterate over each facet and its associated metadata
+      for facet_id, metadata in facet_data.items():
+
+        # Get the value of the specified property from the data
+        prop_value = metadata.get(property_name)
+
+        # Check if the property value matches the specified value
+        if isinstance(value, list):
+          if prop_value in value:
+            matching_facet_ids.append(facet_id)
+        elif prop_value == value:
+          matching_facet_ids.append(facet_id)
+
+    return matching_facet_ids
 
 
 @dataclass

--- a/datacommons_client/endpoints/response.py
+++ b/datacommons_client/endpoints/response.py
@@ -193,6 +193,22 @@ class ObservationResponse(SerializableMixin):
 
     return metadata
 
+  def find_matching_facet_id(self, property_name: str, value: str) -> list[str]:
+    """Finds facet IDs that match a given property and value.
+
+        Args:
+            property_name (str): The property to match.
+            value (str): The value to match.
+
+        Returns:
+            list[str]: A list of facet IDs that match the property and value.
+        """
+    return [
+        facet_id for facet_data in self.get_facets_metadata().values()
+        for facet_id, metadata in facet_data.items()
+        if metadata.get(property_name) == value
+    ]
+
 
 @dataclass
 class ResolveResponse(SerializableMixin):

--- a/datacommons_client/tests/endpoints/test_error_handling.py
+++ b/datacommons_client/tests/endpoints/test_error_handling.py
@@ -7,6 +7,7 @@ from datacommons_client.utils.error_handling import DCAuthenticationError
 from datacommons_client.utils.error_handling import DCConnectionError
 from datacommons_client.utils.error_handling import DCStatusError
 from datacommons_client.utils.error_handling import InvalidDCInstanceError
+from datacommons_client.utils.error_handling import NoDataForPropertyError
 
 
 def test_data_commons_error_default_message():
@@ -58,6 +59,9 @@ def test_subclass_default_messages():
 
   instance_error = InvalidDCInstanceError()
   assert InvalidDCInstanceError.default_message in str(instance_error)
+
+  filter_error = NoDataForPropertyError()
+  assert NoDataForPropertyError.default_message in str(filter_error)
 
 
 def test_subclass_custom_message():

--- a/datacommons_client/tests/endpoints/test_observation_endpoint.py
+++ b/datacommons_client/tests/endpoints/test_observation_endpoint.py
@@ -48,26 +48,26 @@ def test_fetch_latest_observation():
 
   response = endpoint.fetch_latest_observations(
       variable_dcids=["dc/Variable1", "dc/Variable2"],
+      select=["date", "variable", "entity", "value"],
       entity_dcids="dc/EntityID")
 
   # Check the response
   assert isinstance(response, ObservationResponse)
 
   # Check the post request
-  api_mock.post.assert_called_once_with(
-      payload={
-          "variable": {
-              "dcids": ["dc/Variable1", "dc/Variable2"]
-          },
-          "date": ObservationDate.LATEST,
-          "entity": {
-              "dcids": ["dc/EntityID"]
-          },
-          "select": ["date", "variable", "entity", "value"],  # Default select
+  api_mock.post.assert_called_once_with(payload={
+      "date": ObservationDate.LATEST,
+      "variable": {
+          "dcids": ["dc/Variable1", "dc/Variable2"]
       },
-      endpoint="observation",
-      all_pages=True,
-      next_token=None)
+      "entity": {
+          "dcids": ["dc/EntityID"]
+      },
+      "select": ["date", "variable", "entity", "value"],
+  },
+                                        endpoint="observation",
+                                        all_pages=True,
+                                        next_token=None)
 
 
 def test_fetch_latest_observations_by_entity():
@@ -78,6 +78,7 @@ def test_fetch_latest_observations_by_entity():
   response = endpoint.fetch_latest_observations_by_entity(
       variable_dcids="dc/VariableID",
       entity_dcids=["dc/Entity1", "dc/Entity2"],
+      select=["date", "variable", "entity", "value"],
       filter_facet_ids="facet1")
 
   # Check the response
@@ -85,10 +86,10 @@ def test_fetch_latest_observations_by_entity():
 
   # Check the post request
   api_mock.post.assert_called_once_with(payload={
+      "date": ObservationDate.LATEST,
       "variable": {
           "dcids": ["dc/VariableID"]
       },
-      "date": ObservationDate.LATEST,
       "entity": {
           "dcids": ["dc/Entity1", "dc/Entity2"]
       },
@@ -111,6 +112,7 @@ def test_fetch_observations_by_entity_type():
       date="2023",
       parent_entity="Earth",
       entity_type="Country",
+      select=["variable", "entity", "facet"],
       variable_dcids="dc/VariableID")
 
   # Check the response
@@ -118,14 +120,46 @@ def test_fetch_observations_by_entity_type():
 
   # Check the post request
   api_mock.post.assert_called_once_with(payload={
+      "date": "2023",
       "variable": {
           "dcids": ["dc/VariableID"]
       },
-      "date": "2023",
       "entity": {
           "expression": "Earth<-containedInPlace+{typeOf:Country}"
       },
-      "select": ["date", "variable", "entity", "value"],
+      "select": ["variable", "entity", "facet"],
+  },
+                                        endpoint="observation",
+                                        all_pages=True,
+                                        next_token=None)
+
+
+def test_fetch_observations_facets_by_entity_type():
+  """Tests the fetch_observations_by_entity_type method."""
+  api_mock = MagicMock(spec=API)
+  endpoint = ObservationEndpoint(api=api_mock)
+
+  response = endpoint.fetch_observations_by_entity_type(
+      date="2023",
+      parent_entity="Earth",
+      entity_type="Country",
+      variable_dcids="dc/VariableID",
+      select=["variable", "entity", "facet"],
+  )
+
+  # Check the response
+  assert isinstance(response, ObservationResponse)
+
+  # Check the post request
+  api_mock.post.assert_called_once_with(payload={
+      "date": "2023",
+      "variable": {
+          "dcids": ["dc/VariableID"]
+      },
+      "entity": {
+          "expression": "Earth<-containedInPlace+{typeOf:Country}"
+      },
+      "select": ["variable", "entity", "facet"],
   },
                                         endpoint="observation",
                                         all_pages=True,

--- a/datacommons_client/tests/endpoints/test_payloads.py
+++ b/datacommons_client/tests/endpoints/test_payloads.py
@@ -69,7 +69,7 @@ def test_observation_select_invalid_value():
   with pytest.raises(
       InvalidObservationSelectError,
       match=
-      r"Invalid `select` field: 'invalid'. Only date, variable, entity, value are allowed.",
+      r"Invalid `select` field: 'invalid'. Only date, variable, entity, value, facet are allowed.",
   ):
     ObservationSelect("invalid")
 

--- a/datacommons_client/tests/endpoints/test_response.py
+++ b/datacommons_client/tests/endpoints/test_response.py
@@ -851,6 +851,10 @@ def test_find_matching_facet_id():
   result = mock_response.find_matching_facet_id("measurementMethod", "Census")
   assert result == ["facet1"]
 
+  result = mock_response.find_matching_facet_id("measurementMethod",
+                                                ["Census", "Survey"])
+  assert result == ["facet1", "facet2"]
+
   result = mock_response.find_matching_facet_id("unit", "USD")
   assert result == ["facet3"]
 

--- a/datacommons_client/tests/endpoints/test_response.py
+++ b/datacommons_client/tests/endpoints/test_response.py
@@ -1,4 +1,5 @@
 import json
+from unittest.mock import MagicMock
 
 from datacommons_client.endpoints.response import DCResponse
 from datacommons_client.endpoints.response import NodeResponse
@@ -825,3 +826,34 @@ def test_get_facets_metadata():
   }
 
   assert result == expected
+
+
+def test_find_matching_facet_id():
+  """Tests that find_matching_facet_id correctly finds facet IDs matching a given property and value."""
+  mock_response = ObservationResponse(byVariable={}, facets={})
+  mock_response.get_facets_metadata = MagicMock(
+      return_value={
+          "statvar1": {
+              "facet1": {
+                  "measurementMethod": "Census"
+              },
+              "facet2": {
+                  "measurementMethod": "Survey"
+              },
+          },
+          "statvar2": {
+              "facet3": {
+                  "unit": "USD"
+              },
+          },
+      })
+
+  result = mock_response.find_matching_facet_id("measurementMethod", "Census")
+  assert result == ["facet1"]
+
+  result = mock_response.find_matching_facet_id("unit", "USD")
+  assert result == ["facet3"]
+
+  result = mock_response.find_matching_facet_id("measurementMethod",
+                                                "Nonexistent")
+  assert result == []

--- a/datacommons_client/tests/endpoints/test_response.py
+++ b/datacommons_client/tests/endpoints/test_response.py
@@ -601,55 +601,63 @@ def test_resolve_response_dict_exclude_none():
   """Test that ResolveResponse.to_dict and json are consistent."""
   # Input dictionary
   input_data = {
-      "entities": [{
-          "node":
-              "entity1",
-          "candidates": [
-              {
-                  "dcid": "dcid1",
-                  "dominantType": "Type1"
-              },
-              {
-                  "dcid": "dcid2",
-                  "dominantType": None
-              },
-          ],
-      }, {
-          "node": "entity2",
-          "candidates": [{
-              "dcid": "dcid3",
-              "dominantType": "Type2"
-          },],
-      }, {
-          "node": "entity3",
-          "candidates": [],
-      }]
+      "entities": [
+          {
+              "node":
+                  "entity1",
+              "candidates": [
+                  {
+                      "dcid": "dcid1",
+                      "dominantType": "Type1"
+                  },
+                  {
+                      "dcid": "dcid2",
+                      "dominantType": None
+                  },
+              ],
+          },
+          {
+              "node": "entity2",
+              "candidates": [{
+                  "dcid": "dcid3",
+                  "dominantType": "Type2"
+              },],
+          },
+          {
+              "node": "entity3",
+              "candidates": [],
+          },
+      ]
   }
 
   # Expected data
   expected_data = {
-      "entities": [{
-          "node":
-              "entity1",
-          "candidates": [
-              {
-                  "dcid": "dcid1",
-                  "dominantType": "Type1"
-              },
-              {
-                  "dcid": "dcid2"
-              },
-          ],
-      }, {
-          "node": "entity2",
-          "candidates": [{
-              "dcid": "dcid3",
-              "dominantType": "Type2"
-          },],
-      }, {
-          "node": "entity3",
-          "candidates": [],
-      }]
+      "entities": [
+          {
+              "node":
+                  "entity1",
+              "candidates": [
+                  {
+                      "dcid": "dcid1",
+                      "dominantType": "Type1"
+                  },
+                  {
+                      "dcid": "dcid2"
+                  },
+              ],
+          },
+          {
+              "node": "entity2",
+              "candidates": [{
+                  "dcid": "dcid3",
+                  "dominantType": "Type2"
+              },],
+          },
+          {
+              "node": "entity3",
+              "candidates": [],
+          },
+      ]
   }
 
   # Create ResolveResponse from the dictionary
@@ -705,4 +713,115 @@ def test_resolve_response_json_string_exclude_none():
   result = response.to_json(exclude_none=False)
 
   # Assert that the resulting dictionary matches the original input
+  assert result == expected
+
+
+def test_get_facets_metadata():
+  """Test that get_facets_metadata correctly extracts and structures facet metadata."""
+
+  # Mock facet metadata
+  mock_facets = {
+      "facet1": {
+          "unit": "USD",
+          "importName": "Import Source",
+      },
+      "facet2": {
+          "unit": "Year",
+          "importName": "Another Source",
+      },
+  }
+
+  # Mock data for entities and variables
+  mock_data_by_entity = {
+      "variable1": {
+          "entity1": {
+              "orderedFacets": [
+                  OrderedFacets(
+                      facetId="facet1",
+                      earliestDate="2023",
+                      latestDate="2025",
+                      obsCount=5,
+                  )
+              ]
+          },
+          "entity2": {
+              "orderedFacets": [
+                  OrderedFacets(
+                      facetId="facet2",
+                      earliestDate="2021",
+                      latestDate="2021",
+                      obsCount=3,
+                  )
+              ]
+          },
+      },
+      "variable2": {
+          "entity3": {
+              "orderedFacets": [
+                  OrderedFacets(
+                      facetId="facet1",
+                      earliestDate="2000",
+                      latestDate="2013",
+                      obsCount=7,
+                  )
+              ]
+          }
+      },
+  }
+
+  # Mock ObservationResponse
+  response = ObservationResponse(byVariable={})
+  response.get_data_by_entity = lambda: mock_data_by_entity
+  response.to_dict = lambda: {"facets": mock_facets}
+
+  # Call the method
+  result = response.get_facets_metadata()
+
+  # Expected structure
+  expected = {
+      "variable1": {
+          "facet1": {
+              "earliestDate": {
+                  "entity1": "2023"
+              },
+              "latestDate": {
+                  "entity1": "2025"
+              },
+              "obsCount": {
+                  "entity1": 5
+              },
+              "unit": "USD",
+              "importName": "Import Source",
+          },
+          "facet2": {
+              "earliestDate": {
+                  "entity2": "2021"
+              },
+              "latestDate": {
+                  "entity2": "2021"
+              },
+              "obsCount": {
+                  "entity2": 3
+              },
+              "unit": "Year",
+              "importName": "Another Source",
+          },
+      },
+      "variable2": {
+          "facet1": {
+              "earliestDate": {
+                  "entity3": "2000"
+              },
+              "latestDate": {
+                  "entity3": "2013"
+              },
+              "obsCount": {
+                  "entity3": 7
+              },
+              "unit": "USD",
+              "importName": "Import Source",
+          }
+      },
+  }
+
   assert result == expected

--- a/datacommons_client/utils/error_handling.py
+++ b/datacommons_client/utils/error_handling.py
@@ -81,3 +81,9 @@ class InvalidObservationSelectError(DataCommonsError):
   """Raised when an invalid ObservationSelect field is provided."""
 
   default_message = "The ObservationSelect field is invalid."
+
+
+class NoDataForPropertyError(DataCommonsError):
+  """Raised when there is no data that meets the specified property filters."""
+
+  default_message = "No available data for the specified property filters."


### PR DESCRIPTION
This is an exciting new feature, inspired by our recent work on supporting the Observation facet filters.

**TL;DR**
This PR makes it possible to specify property filters so that only the relevant observations are fetched. This could substantially reduce the amount of data transferred if users specify a particular `unit`, `measurementMethod`, `observationPeriod`, etc.

---

Sample usage:

```python
from datacommons_client import DataCommonsClient

dc = DataCommonsClient(dc_instance="datacommons.one.org")

df = dc.observations_dataframe(
    variable_dcids=["Count_Person"],
    date="all",
    entity_dcids=["country/USA"],
    property_filters={
        "measurementMethod": ["CensusACS5yrSurvey", "OECDRegionalStatistics"]
    },
)
```

The above will make a first call to the Observations endpoint to get the facets information (without fetching the observations themselves). It will then find for which facets it should fetch observations, and make that more 'expensive' call only for the required facets.

In this case, 83 observations are returned. The `property_filters` parameter is optional.  Without filtering for "measurementMethod" it would return all measurementMethods, which total 507 observations.

The `property_filters` parameter takes in a dictionary. Users can specify any property as a key and a string or list of strings as a value.

---

To enable the behaviour described above, this PR introduces the following changes:
**DataCommonsClient** class
- A `property_filters` parameter for the `observations_dataframe` method.
- A helper function (`_find_filter_facet_ids` to find which facets should be fetched, based on the `property_filters`)

**ObservationsEndpoint** class
- Optional parameter to specify `select` in all convenience methods (instead of just for `fetch`)

**ObservationsSelect** enum
-  Support for "facet"

**ObservationResponse** class
- `get_facets_metadata` to extract metadata from the response object (including start date, end date, number of observations, properties like measurementMethod, units, etc)

The PR also includes new tests for this functionality and modifies some existing tests accordingly.

---

@kmoscoe FYI
