### PR TITLE
Fix typehint

### DIFF
--- a/datacommons_client/endpoints/node.py
+++ b/datacommons_client/endpoints/node.py
@@ -22,7 +22,7 @@ class NodeEndpoint(Endpoint):
   def fetch(
       self,
       node_dcids: str | list[str],
-      expression: str | list[str],
+      expression: str,
       *,
       all_pages: bool = True,
       next_token: Optional[str] = None,
@@ -31,7 +31,7 @@ class NodeEndpoint(Endpoint):
 
         Args:
             node_dcids (str | List[str]): The DCID(s) of the nodes to query.
-            expression (str | List[str]): The property or relation expression(s) to query.
+            expression (str): The property or relation expression(s) to query.
             all_pages: If True, fetch all pages of the response. If False, fetch only the first page.
               Defaults to True. Set to False to only fetch the first page. In that case, a
               `next_token` key in the response will indicate if more pages are available.

--- a/datacommons_client/tests/endpoints/test_node_endpoint.py
+++ b/datacommons_client/tests/endpoints/test_node_endpoint.py
@@ -41,34 +41,6 @@ def test_node_endpoint_fetch():
   assert "test_node" in response.data
 
 
-def test_node_endpoint_fetch_list_input():
-  """Test the fetch method with list inputs for node_dcids and expression."""
-  api_mock = MagicMock(spec=API)
-  api_mock.post.return_value = {
-      "data": {
-          "test_node": {
-              "properties": {
-                  "name": "Test"
-              }
-          }
-      }
-  }
-
-  endpoint = NodeEndpoint(api=api_mock)
-  response = endpoint.fetch(node_dcids=["test_node1", "test_node2"],
-                            expression=["name", "typeOf"])
-
-  api_mock.post.assert_called_once_with(payload={
-      "nodes": ["test_node1", "test_node2"],
-      "property": "[name, typeOf]",
-  },
-                                        endpoint="node",
-                                        all_pages=True,
-                                        next_token=None)
-  assert isinstance(response, NodeResponse)
-  assert "test_node" in response.data
-
-
 def test_node_endpoint_fetch_property_labels():
   """Test fetch_property_labels method."""
   api_mock = MagicMock(spec=API)


### PR DESCRIPTION
With thanks to @kmoscoe for spotting this. The API does not accept lists of expressions (it needs to start with an arrow which makes it impossible to ask for multiple properties this way, for example).

This PR fixes the `node.fetch` typehint since only strings (and not lists of strings) are accepted. It also removes a related test.