### PR TITLE
`fetch_dcids_by_wikidata_id` improvement

### DIFF
--- a/datacommons_client/endpoints/resolve.py
+++ b/datacommons_client/endpoints/resolve.py
@@ -83,23 +83,23 @@ class ResolveEndpoint(Endpoint):
 
   def fetch_dcids_by_wikidata_id(
       self,
-      wikidata_id: str | list[str],
+      wikidata_ids: str | list[str],
       entity_type: Optional[str] = None) -> ResolveResponse:
     """
-        Fetches DCIDs for entities by their Wikidata IDs.
+          Fetches DCIDs for entities by their Wikidata IDs.
 
-        Args:
-            wikidata_id (str | list[str]): One or more Wikidata IDs to resolve.
-            entity_type (Optional[str]): Optional type of the entities.
+          Args:
+              wikidata_ids (str | list[str]): One or more Wikidata IDs to resolve.
+              entity_type (Optional[str]): Optional type of the entities.
 
-        Returns:
-            ResolveResponse: The response object containing the resolved DCIDs.
-        """
+          Returns:
+              ResolveResponse: The response object containing the resolved DCIDs.
+          """
     expression = _resolve_correspondence_expression(from_type="wikidataId",
                                                     to_type="dcid",
                                                     entity_type=entity_type)
 
-    return self.fetch(node_ids=wikidata_id, expression=expression)
+    return self.fetch(node_ids=wikidata_ids, expression=expression)
 
   def fetch_dcid_by_coordinates(
       self,

--- a/datacommons_client/endpoints/resolve.py
+++ b/datacommons_client/endpoints/resolve.py
@@ -105,7 +105,7 @@ class ResolveEndpoint(Endpoint):
 
     return self.fetch(node_ids=names, expression=expression)
 
-  def fetch_dcid_by_wikidata_id(
+  def fetch_dcids_by_wikidata_id(
       self,
       wikidata_id: str | list[str],
       entity_type: Optional[str] = None) -> ResolveResponse:

--- a/datacommons_client/tests/endpoints/test_resolve_endpoint.py
+++ b/datacommons_client/tests/endpoints/test_resolve_endpoint.py
@@ -53,8 +53,8 @@ def test_fetch_dcid_by_wikidata_id():
   api_mock = MagicMock(spec=API)
   endpoint = ResolveEndpoint(api=api_mock)
 
-  response = endpoint.fetch_dcid_by_wikidata_id(wikidata_id="Q12345",
-                                                entity_type="Country")
+  response = endpoint.fetch_dcids_by_wikidata_id(wikidata_id="Q12345",
+                                                 entity_type="Country")
 
   # Check the response
   assert isinstance(response, ResolveResponse)
@@ -63,6 +63,27 @@ def test_fetch_dcid_by_wikidata_id():
   api_mock.post.assert_called_once_with(payload={
       "nodes": ["Q12345"],
       "property": "<-wikidataId{typeOf:Country}->dcid",
+  },
+                                        endpoint="resolve",
+                                        all_pages=True,
+                                        next_token=None)
+
+
+def test_fetch_dcids_list_by_wikidata_id():
+  """Tests the fetch_dcid_by_wikidata_id method."""
+  api_mock = MagicMock(spec=API)
+  endpoint = ResolveEndpoint(api=api_mock)
+
+  response = endpoint.fetch_dcids_by_wikidata_id(
+      wikidata_id=["Q12345", "Q695660"])
+
+  # Check the response
+  assert isinstance(response, ResolveResponse)
+
+  # Check the post request
+  api_mock.post.assert_called_once_with(payload={
+      "nodes": ["Q12345", "Q695660"],
+      "property": "<-wikidataId->dcid",
   },
                                         endpoint="resolve",
                                         all_pages=True,

--- a/datacommons_client/tests/endpoints/test_resolve_endpoint.py
+++ b/datacommons_client/tests/endpoints/test_resolve_endpoint.py
@@ -52,7 +52,7 @@ def test_fetch_dcid_by_wikidata_id():
   api_mock = MagicMock(spec=API)
   endpoint = ResolveEndpoint(api=api_mock)
 
-  response = endpoint.fetch_dcids_by_wikidata_id(wikidata_id="Q12345",
+  response = endpoint.fetch_dcids_by_wikidata_id(wikidata_ids="Q12345",
                                                  entity_type="Country")
 
   # Check the response
@@ -74,7 +74,7 @@ def test_fetch_dcids_list_by_wikidata_id():
   endpoint = ResolveEndpoint(api=api_mock)
 
   response = endpoint.fetch_dcids_by_wikidata_id(
-      wikidata_id=["Q12345", "Q695660"])
+      wikidata_ids=["Q12345", "Q695660"])
 
   # Check the response
   assert isinstance(response, ResolveResponse)


### PR DESCRIPTION
With thanks to @kmoscoe for spotting the naming inconsistency, this PR:
- Renames `.fetch_dcid_by_wikidata_id` to `fetch_dcids_by_wikidata_id` to clarify lists are accepted.
- Adds a test for lists of `wikidata_ids`