### PR TITLE
Refactor `flatten_resolve_response`

### DIFF
--- a/datacommons_client/endpoints/resolve.py
+++ b/datacommons_client/endpoints/resolve.py
@@ -1,33 +1,9 @@
-from typing import Any, Optional
+from typing import Optional
 
 from datacommons_client.endpoints.base import API
 from datacommons_client.endpoints.base import Endpoint
 from datacommons_client.endpoints.payloads import ResolveRequestPayload
 from datacommons_client.endpoints.response import ResolveResponse
-
-
-def flatten_resolve_response(
-    data: ResolveResponse) -> dict[str, list[str] | str]:
-  """
-    Flattens resolved candidate data into a dictionary where each node maps to its candidates.
-
-    Args:
-        data (ResolveResponse): The response object containing the resolved data.
-
-    Returns:
-        dict[str, Any]: A dictionary mapping nodes to their candidates.
-        If a node has only one candidate, it maps directly to the candidate instead of a list.
-    """
-  items: dict[str, Any] = {}
-
-  for entity in data.entities:
-    node = entity.node
-    if len(entity.candidates) == 1:
-      items[node] = entity.candidates[0].dcid
-    else:
-      items[node] = [candidate.dcid for candidate in entity.candidates]
-
-  return items
 
 
 def _resolve_correspondence_expression(from_type: str,

--- a/datacommons_client/endpoints/response.py
+++ b/datacommons_client/endpoints/response.py
@@ -250,3 +250,22 @@ class ResolveResponse(SerializableMixin):
     return cls(entities=[
         Entity.from_json(entity) for entity in json_data.get("entities", [])
     ])
+
+  def to_flat_dict(self) -> dict[str, list[str] | str]:
+    """
+      Flattens resolved candidate data into a dictionary where each node maps to its candidates.
+
+      Returns:
+          dict[str, Any]: A dictionary mapping nodes to their candidates.
+          If a node has only one candidate, it maps directly to the candidate instead of a list.
+      """
+    items: dict[str, Any] = {}
+
+    for entity in self.entities:
+      node = entity.node
+      if len(entity.candidates) == 1:
+        items[node] = entity.candidates[0].dcid
+      else:
+        items[node] = [candidate.dcid for candidate in entity.candidates]
+
+    return items

--- a/datacommons_client/tests/endpoints/test_resolve_endpoint.py
+++ b/datacommons_client/tests/endpoints/test_resolve_endpoint.py
@@ -2,7 +2,6 @@ from unittest.mock import MagicMock
 
 from datacommons_client.endpoints.base import API
 from datacommons_client.endpoints.resolve import _resolve_correspondence_expression
-from datacommons_client.endpoints.resolve import flatten_resolve_response
 from datacommons_client.endpoints.resolve import ResolveEndpoint
 from datacommons_client.endpoints.response import ResolveResponse
 
@@ -119,7 +118,7 @@ def test_flatten_resolve_response():
   ])
 
   # Call the function
-  result = flatten_resolve_response(mock_data)
+  result = mock_data.to_flat_dict()
 
   # Expected output
   expected = {


### PR DESCRIPTION
Move the logic from a standalone `flatten_respolve_response` function, to a method of the Response object. That way it complements `to_dict`, `to_json` with `to_flat_dict`.

Example usage:

```python
from datacommons_client import DataCommonsClient

dc = DataCommonsClient(dc_instance="datacommons.one.org")

response = dc.resolve.fetch_dcids_by_name(
    ["Guatemala", "France", "Germany", "United States", "United Kingdom"],
    entity_type="Country",
)
```

This would return a `ResolveResponse` object. 

Calling the regular `to_dict` would look like this, keeping the original response structure and nesting intact.

```python
response.to_dict()

{'entities': [{'candidates': [{'dcid': 'country/FRA'}, {'dcid': 'country/FXX'}],
               'node': 'France'},
              {'candidates': [{'dcid': 'country/DEU'}], 'node': 'Germany'},
              {'candidates': [{'dcid': 'country/GTM'}], 'node': 'Guatemala'},
              {'candidates': [{'dcid': 'country/GBR'}],
               'node': 'United Kingdom'},
              {'candidates': [{'dcid': 'country/USA'}],
               'node': 'United States'}]}
```

Calling `to_flat_dict` will create a direct mapping between the name and the dcid candidate(s).

```python
response.to_flat_dict()

{'France': ['country/FRA', 'country/FXX'],
 'Germany': 'country/DEU',
 'Guatemala': 'country/GTM',
 'United Kingdom': 'country/GBR',
 'United States': 'country/USA'}

```

Thanks to @kmoscoe for highlighting issues with clarity in the previous implementation!