### PR TITLE
Add `fetch_entity_names` method

### DIFF
--- a/datacommons_client/endpoints/node.py
+++ b/datacommons_client/endpoints/node.py
@@ -196,7 +196,7 @@ class NodeEndpoint(Endpoint):
       entity_dcids: str | list[str],
       language: Optional[str] = DEFAULT_NAME_LANGUAGE,
       fallback_language: Optional[str] = None,
-  ) -> dict[str, str]:
+  ) -> dict[str, dict[str, str]]:
     """
         Fetches entity names in the specified language, with optional fallback to English.
         Args:
@@ -205,7 +205,8 @@ class NodeEndpoint(Endpoint):
           fallback_language: If provided, this language will be used as a fallback if the requested
             language is not available. If not provided, no fallback will be used.
         Returns:
-          A dictionary mapping each DCID to its name (in the requested or fallback language).
+          A dictionary mapping each DCID to a dictionary with the mapped name, language, and
+            the property used.
         """
 
     # Check if entity_dcids is a single string. If so, convert it to a list.
@@ -220,19 +221,24 @@ class NodeEndpoint(Endpoint):
     data = self.fetch_property_values(
         node_dcids=entity_dcids, properties=name_property).get_properties()
 
-    names: dict[str, str] = {}
+    names: dict[str, dict[str, str]] = {}
 
     # Iterate through the fetched data and populate the names dictionary.
     for dcid, properties in data.items():
       if language == "en":
         name = extract_name_from_english_name_property(properties=properties)
+        lang_used = "en"
       else:
-        name = extract_name_from_property_with_language(
+        name, lang_used = extract_name_from_property_with_language(
             properties=properties,
             language=language,
             fallback_language=fallback_language,
         )
       if name:
-        names[dcid] = name
+        names[dcid] = {
+            "value": name,
+            "language": lang_used,
+            "property": name_property,
+        }
 
     return names

--- a/datacommons_client/endpoints/node.py
+++ b/datacommons_client/endpoints/node.py
@@ -5,8 +5,11 @@ from datacommons_client.endpoints.base import Endpoint
 from datacommons_client.endpoints.payloads import NodeRequestPayload
 from datacommons_client.endpoints.payloads import normalize_properties_to_string
 from datacommons_client.endpoints.response import NodeResponse
+from datacommons_client.utils.names import DEFAULT_NAME_LANGUAGE
+from datacommons_client.utils.names import DEFAULT_NAME_PROPERTY
 from datacommons_client.utils.names import extract_name_from_english_name_property
 from datacommons_client.utils.names import extract_name_from_property_with_language
+from datacommons_client.utils.names import NAME_WITH_LANGUAGE_PROPERTY
 
 
 class NodeEndpoint(Endpoint):
@@ -191,16 +194,16 @@ class NodeEndpoint(Endpoint):
   def fetch_entity_names(
       self,
       entity_dcids: str | list[str],
-      language: Optional[str] = "en",
-      fallback_to_en: bool = False,
+      language: Optional[str] = DEFAULT_NAME_LANGUAGE,
+      fallback_language: Optional[str] = None,
   ) -> dict[str, str]:
     """
         Fetches entity names in the specified language, with optional fallback to English.
         Args:
           entity_dcids: A single DCID or a list of DCIDs to fetch names for.
-          language: Language code (e.g., "en", "es"). Defaults to "en".
-          fallback_to_en: If True, falls back to English if the desired language is not found.
-            Defaults to False.
+          language: Language code (e.g., "en", "es"). Defaults to "en" (DEFAULT_NAME_LANGUAGE).
+          fallback_language: If provided, this language will be used as a fallback if the requested
+            language is not available. If not provided, no fallback will be used.
         Returns:
           A dictionary mapping each DCID to its name (in the requested or fallback language).
         """
@@ -210,7 +213,8 @@ class NodeEndpoint(Endpoint):
       entity_dcids = [entity_dcids]
 
     # If langauge is English, use the more efficient 'name' property.
-    name_property = "name" if language == "en" else "nameWithLanguage"
+    name_property = (DEFAULT_NAME_PROPERTY if language == DEFAULT_NAME_LANGUAGE
+                     else NAME_WITH_LANGUAGE_PROPERTY)
 
     # Fetch names the given entity DCIDs.
     data = self.fetch_property_values(
@@ -226,7 +230,7 @@ class NodeEndpoint(Endpoint):
         name = extract_name_from_property_with_language(
             properties=properties,
             language=language,
-            fallback_to_en=fallback_to_en,
+            fallback_language=fallback_language,
         )
       if name:
         names[dcid] = name

--- a/datacommons_client/endpoints/node.py
+++ b/datacommons_client/endpoints/node.py
@@ -5,6 +5,7 @@ from datacommons_client.endpoints.base import Endpoint
 from datacommons_client.endpoints.payloads import NodeRequestPayload
 from datacommons_client.endpoints.payloads import normalize_properties_to_string
 from datacommons_client.endpoints.response import NodeResponse
+from datacommons_client.models.node import Name
 from datacommons_client.utils.names import DEFAULT_NAME_LANGUAGE
 from datacommons_client.utils.names import DEFAULT_NAME_PROPERTY
 from datacommons_client.utils.names import extract_name_from_english_name_property
@@ -196,7 +197,7 @@ class NodeEndpoint(Endpoint):
       entity_dcids: str | list[str],
       language: Optional[str] = DEFAULT_NAME_LANGUAGE,
       fallback_language: Optional[str] = None,
-  ) -> dict[str, dict[str, str]]:
+  ) -> dict[str, Name]:
     """
         Fetches entity names in the specified language, with optional fallback to English.
         Args:
@@ -221,7 +222,7 @@ class NodeEndpoint(Endpoint):
     data = self.fetch_property_values(
         node_dcids=entity_dcids, properties=name_property).get_properties()
 
-    names: dict[str, dict[str, str]] = {}
+    names: dict[str, Name] = {}
 
     # Iterate through the fetched data and populate the names dictionary.
     for dcid, properties in data.items():
@@ -235,10 +236,10 @@ class NodeEndpoint(Endpoint):
             fallback_language=fallback_language,
         )
       if name:
-        names[dcid] = {
-            "value": name,
-            "language": lang_used,
-            "property": name_property,
-        }
+        names[dcid] = Name(
+            value=name,
+            language=lang_used,
+            property=name_property,
+        )
 
     return names

--- a/datacommons_client/endpoints/response.py
+++ b/datacommons_client/endpoints/response.py
@@ -1,9 +1,8 @@
-from dataclasses import asdict
 from dataclasses import dataclass
 from dataclasses import field
-import json
 from typing import Any, Dict, List
 
+from datacommons_client.models.base import SerializableMixin
 from datacommons_client.models.node import Arcs
 from datacommons_client.models.node import NextToken
 from datacommons_client.models.node import NodeDCID
@@ -15,42 +14,6 @@ from datacommons_client.models.observation import variableDCID
 from datacommons_client.models.resolve import Entity
 from datacommons_client.utils.data_processing import flatten_properties
 from datacommons_client.utils.data_processing import observations_as_records
-
-
-class SerializableMixin:
-  """Provides serialization methods for the Response dataclasses."""
-
-  def to_dict(self, exclude_none: bool = True) -> Dict[str, Any]:
-    """Converts the instance to a dictionary.
-
-        Args:
-            exclude_none: If True, only include non-empty values in the response.
-
-        Returns:
-            Dict[str, Any]: The dictionary representation of the instance.
-        """
-
-    def _remove_none(data: Any) -> Any:
-      """Recursively removes None or empty values from a dictionary or list."""
-      if isinstance(data, dict):
-        return {k: _remove_none(v) for k, v in data.items() if v is not None}
-      elif isinstance(data, list):
-        return [_remove_none(item) for item in data]
-      return data
-
-    result = asdict(self)
-    return _remove_none(result) if exclude_none else result
-
-  def to_json(self, exclude_none: bool = True) -> str:
-    """Converts the instance to a JSON string.
-
-        Args:
-            exclude_none: If True, only include non-empty values in the response.
-
-        Returns:
-            str: The JSON string representation of the instance.
-        """
-    return json.dumps(self.to_dict(exclude_none=exclude_none), indent=2)
 
 
 @dataclass

--- a/datacommons_client/models/base.py
+++ b/datacommons_client/models/base.py
@@ -1,0 +1,39 @@
+from dataclasses import asdict
+import json
+from typing import Any, Dict
+
+
+class SerializableMixin:
+  """Provides serialization methods for the Response dataclasses."""
+
+  def to_dict(self, exclude_none: bool = True) -> Dict[str, Any]:
+    """Converts the instance to a dictionary.
+
+        Args:
+            exclude_none: If True, only include non-empty values in the response.
+
+        Returns:
+            Dict[str, Any]: The dictionary representation of the instance.
+        """
+
+    def _remove_none(data: Any) -> Any:
+      """Recursively removes None or empty values from a dictionary or list."""
+      if isinstance(data, dict):
+        return {k: _remove_none(v) for k, v in data.items() if v is not None}
+      elif isinstance(data, list):
+        return [_remove_none(item) for item in data]
+      return data
+
+    result = asdict(self)
+    return _remove_none(result) if exclude_none else result
+
+  def to_json(self, exclude_none: bool = True) -> str:
+    """Converts the instance to a JSON string.
+
+        Args:
+            exclude_none: If True, only include non-empty values in the response.
+
+        Returns:
+            str: The JSON string representation of the instance.
+        """
+    return json.dumps(self.to_dict(exclude_none=exclude_none), indent=2)

--- a/datacommons_client/models/node.py
+++ b/datacommons_client/models/node.py
@@ -2,6 +2,8 @@ from dataclasses import dataclass
 from dataclasses import field
 from typing import Any, Dict, List, Optional, TypeAlias
 
+from datacommons_client.models.base import SerializableMixin
+
 NextToken: TypeAlias = Optional[str]
 NodeDCID: TypeAlias = str
 ArcLabel: TypeAlias = str
@@ -10,7 +12,7 @@ PropertyList: TypeAlias = list[Property]
 
 
 @dataclass
-class Node:
+class Node(SerializableMixin):
   """Represents an individual node in the Data Commons knowledge graph.
 
     Attributes:
@@ -36,6 +38,21 @@ class Node:
         types=json_data.get("types"),
         value=json_data.get("value"),
     )
+
+
+@dataclass
+class Name(SerializableMixin):
+  """Represents a name associated with an Entity (node).
+
+    Attributes:
+        value: The name of the Entity
+        language: The language of the name
+        property: The property used to get the name
+    """
+
+  value: str
+  language: str
+  property: str
 
 
 @dataclass

--- a/datacommons_client/tests/endpoints/test_node_endpoint.py
+++ b/datacommons_client/tests/endpoints/test_node_endpoint.py
@@ -1,8 +1,11 @@
 from unittest.mock import MagicMock
+from unittest.mock import patch
 
 from datacommons_client.endpoints.base import API
 from datacommons_client.endpoints.node import NodeEndpoint
 from datacommons_client.endpoints.response import NodeResponse
+from datacommons_client.utils.names import DEFAULT_NAME_PROPERTY
+from datacommons_client.utils.names import NAME_WITH_LANGUAGE_PROPERTY
 
 
 def test_node_endpoint_initialization():
@@ -30,13 +33,15 @@ def test_node_endpoint_fetch():
   endpoint = NodeEndpoint(api=api_mock)
   response = endpoint.fetch(node_dcids="test_node", expression="name")
 
-  api_mock.post.assert_called_once_with(payload={
-      "nodes": ["test_node"],
-      "property": "name"
-  },
-                                        endpoint="node",
-                                        all_pages=True,
-                                        next_token=None)
+  api_mock.post.assert_called_once_with(
+      payload={
+          "nodes": ["test_node"],
+          "property": "name"
+      },
+      endpoint="node",
+      all_pages=True,
+      next_token=None,
+  )
   assert isinstance(response, NodeResponse)
   assert "test_node" in response.data
 
@@ -80,13 +85,15 @@ def test_node_endpoint_fetch_property_values_out():
                                             out=True)
 
   expected_expression = "->name{typeOf:City}"
-  api_mock.post.assert_called_once_with(payload={
-      "nodes": ["node1"],
-      "property": expected_expression
-  },
-                                        endpoint="node",
-                                        all_pages=True,
-                                        next_token=None)
+  api_mock.post.assert_called_once_with(
+      payload={
+          "nodes": ["node1"],
+          "property": expected_expression
+      },
+      endpoint="node",
+      all_pages=True,
+      next_token=None,
+  )
   assert isinstance(response, NodeResponse)
   assert "node1" in response.data
 
@@ -112,13 +119,15 @@ def test_node_endpoint_fetch_property_values_in():
                                             out=False)
 
   expected_expression = "<-name{typeOf:City}"
-  api_mock.post.assert_called_once_with(payload={
-      "nodes": ["node1"],
-      "property": expected_expression
-  },
-                                        endpoint="node",
-                                        all_pages=True,
-                                        next_token=None)
+  api_mock.post.assert_called_once_with(
+      payload={
+          "nodes": ["node1"],
+          "property": expected_expression
+      },
+      endpoint="node",
+      all_pages=True,
+      next_token=None,
+  )
   assert isinstance(response, NodeResponse)
   assert "node1" in response.data
 
@@ -133,11 +142,13 @@ def test_node_endpoint_fetch_all_classes():
       }}))
 
   response = endpoint.fetch_all_classes()
-  endpoint.fetch_property_values.assert_called_once_with(node_dcids="Class",
-                                                         properties="typeOf",
-                                                         out=False,
-                                                         all_pages=True,
-                                                         next_token=None)
+  endpoint.fetch_property_values.assert_called_once_with(
+      node_dcids="Class",
+      properties="typeOf",
+      out=False,
+      all_pages=True,
+      next_token=None,
+  )
   assert isinstance(response, NodeResponse)
   assert "Class" in response.data
 
@@ -162,23 +173,148 @@ def test_node_endpoint_fetch_property_values_string_vs_list():
                                             properties="name",
                                             constraints=None,
                                             out=True)
-  api_mock.post.assert_called_with(payload={
-      "nodes": ["node1"],
-      "property": "->name"
-  },
-                                   endpoint="node",
-                                   all_pages=True,
-                                   next_token=None)
+  api_mock.post.assert_called_with(
+      payload={
+          "nodes": ["node1"],
+          "property": "->name"
+      },
+      endpoint="node",
+      all_pages=True,
+      next_token=None,
+  )
 
   # List input
   response = endpoint.fetch_property_values(node_dcids="node1",
                                             properties=["name", "typeOf"],
                                             constraints=None,
                                             out=True)
-  api_mock.post.assert_called_with(payload={
-      "nodes": ["node1"],
-      "property": "->[name, typeOf]"
-  },
-                                   endpoint="node",
-                                   all_pages=True,
-                                   next_token=None)
+  api_mock.post.assert_called_with(
+      payload={
+          "nodes": ["node1"],
+          "property": "->[name, typeOf]"
+      },
+      endpoint="node",
+      all_pages=True,
+      next_token=None,
+  )
+
+
+@patch(
+    "datacommons_client.endpoints.node.extract_name_from_english_name_property")
+def test_fetch_entity_names_english(mock_extract_name):
+  """Test fetching names in English (default behavior)."""
+  mock_extract_name.return_value = "Guatemala"
+  api_mock = MagicMock()
+  endpoint = NodeEndpoint(api=api_mock)
+
+  # Mock the response from fetch_property_values
+  endpoint.fetch_property_values = MagicMock(return_value=NodeResponse(
+      data={
+          "dc/123": {
+              "properties": {
+                  DEFAULT_NAME_PROPERTY: [{
+                      "value": "Guatemala"
+                  }]
+              }
+          }
+      }))
+
+  result = endpoint.fetch_entity_names("dc/123")
+  endpoint.fetch_property_values.assert_called_once_with(
+      node_dcids=["dc/123"], properties=DEFAULT_NAME_PROPERTY)
+  assert result == {
+      "dc/123": {
+          "value": "Guatemala",
+          "language": "en",
+          "property": DEFAULT_NAME_PROPERTY,
+      }
+  }
+  mock_extract_name.assert_called_once()
+
+
+@patch(
+    "datacommons_client.endpoints.node.extract_name_from_property_with_language"
+)
+def test_fetch_entity_names_non_english(mock_extract_name):
+  """Test fetching names in a non-English language."""
+  mock_extract_name.return_value = ("Californie", "fr")
+  api_mock = MagicMock()
+  endpoint = NodeEndpoint(api=api_mock)
+
+  endpoint.fetch_property_values = MagicMock(return_value=NodeResponse(
+      data={
+          "dc/123": {
+              "properties": {
+                  NAME_WITH_LANGUAGE_PROPERTY: [{
+                      "value": "Californie",
+                      "lang": "fr"
+                  }]
+              }
+          }
+      }))
+
+  result = endpoint.fetch_entity_names("dc/123", language="fr")
+  endpoint.fetch_property_values.assert_called_once_with(
+      node_dcids=["dc/123"], properties=NAME_WITH_LANGUAGE_PROPERTY)
+  assert result == {
+      "dc/123": {
+          "value": "Californie",
+          "language": "fr",
+          "property": NAME_WITH_LANGUAGE_PROPERTY,
+      }
+  }
+  mock_extract_name.assert_called_once()
+
+
+@patch(
+    "datacommons_client.endpoints.node.extract_name_from_property_with_language"
+)
+def test_fetch_entity_names_with_fallback(mock_extract_name_lang):
+  """Test fallback to another language when target language is unavailable."""
+  mock_extract_name_lang.return_value = ("Chiquimula", "en")
+  api_mock = MagicMock()
+  endpoint = NodeEndpoint(api=api_mock)
+
+  endpoint.fetch_property_values = MagicMock(return_value=NodeResponse(
+      data={
+          "dc/123": {
+              "properties": {
+                  NAME_WITH_LANGUAGE_PROPERTY: [{
+                      "value": "Chiquimula",
+                      "lang": "en"
+                  }]
+              }
+          }
+      }))
+
+  result = endpoint.fetch_entity_names("dc/123",
+                                       language="fr",
+                                       fallback_language="en")
+
+  assert result == {
+      "dc/123": {
+          "value": "Chiquimula",
+          "language": "en",
+          "property": NAME_WITH_LANGUAGE_PROPERTY,
+      }
+  }
+
+
+@patch(
+    "datacommons_client.endpoints.node.extract_name_from_property_with_language"
+)
+def test_fetch_entity_names_no_result(mock_extract_name_lang):
+  """Test case when no name is found."""
+  mock_extract_name_lang.return_value = (None, None)
+  api_mock = MagicMock()
+  endpoint = NodeEndpoint(api=api_mock)
+
+  endpoint.fetch_property_values = MagicMock(return_value=NodeResponse(
+      data={"dc/999": {
+          "properties": {}
+      }}))
+
+  result = endpoint.fetch_entity_names("dc/999",
+                                       language="es",
+                                       fallback_language="en")
+  assert result == {}

--- a/datacommons_client/tests/endpoints/test_node_endpoint.py
+++ b/datacommons_client/tests/endpoints/test_node_endpoint.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 from datacommons_client.endpoints.base import API
 from datacommons_client.endpoints.node import NodeEndpoint
 from datacommons_client.endpoints.response import NodeResponse
+from datacommons_client.models.node import Name
 from datacommons_client.utils.names import DEFAULT_NAME_PROPERTY
 from datacommons_client.utils.names import NAME_WITH_LANGUAGE_PROPERTY
 
@@ -223,12 +224,14 @@ def test_fetch_entity_names_english(mock_extract_name):
   endpoint.fetch_property_values.assert_called_once_with(
       node_dcids=["dc/123"], properties=DEFAULT_NAME_PROPERTY)
   assert result == {
-      "dc/123": {
-          "value": "Guatemala",
-          "language": "en",
-          "property": DEFAULT_NAME_PROPERTY,
-      }
+      "dc/123":
+          Name(
+              value="Guatemala",
+              language="en",
+              property=DEFAULT_NAME_PROPERTY,
+          )
   }
+
   mock_extract_name.assert_called_once()
 
 
@@ -257,12 +260,14 @@ def test_fetch_entity_names_non_english(mock_extract_name):
   endpoint.fetch_property_values.assert_called_once_with(
       node_dcids=["dc/123"], properties=NAME_WITH_LANGUAGE_PROPERTY)
   assert result == {
-      "dc/123": {
-          "value": "Californie",
-          "language": "fr",
-          "property": NAME_WITH_LANGUAGE_PROPERTY,
-      }
+      "dc/123":
+          Name(
+              value="Californie",
+              language="fr",
+              property=NAME_WITH_LANGUAGE_PROPERTY,
+          )
   }
+
   mock_extract_name.assert_called_once()
 
 
@@ -292,11 +297,12 @@ def test_fetch_entity_names_with_fallback(mock_extract_name_lang):
                                        fallback_language="en")
 
   assert result == {
-      "dc/123": {
-          "value": "Chiquimula",
-          "language": "en",
-          "property": NAME_WITH_LANGUAGE_PROPERTY,
-      }
+      "dc/123":
+          Name(
+              value="Chiquimula",
+              language="en",
+              property=NAME_WITH_LANGUAGE_PROPERTY,
+          )
   }
 
 

--- a/datacommons_client/tests/test_names.py
+++ b/datacommons_client/tests/test_names.py
@@ -26,7 +26,8 @@ def test_extract_name_from_property_with_language_match():
   result = extract_name_from_property_with_language(properties,
                                                     language="es",
                                                     fallback_language="en")
-  assert result == "Nombre"
+  assert result[0] == "Nombre"
+  assert result[1] == "es"
 
 
 def test_extract_name_from_property_with_language_fallback():
@@ -39,7 +40,8 @@ def test_extract_name_from_property_with_language_fallback():
   result = extract_name_from_property_with_language(properties,
                                                     language="de",
                                                     fallback_language="it")
-  assert result == "Nome"
+  assert result[0] == "Nome"
+  assert result[1] == "it"
 
 
 def test_extract_name_from_property_with_language_no_fallback():
@@ -49,7 +51,8 @@ def test_extract_name_from_property_with_language_no_fallback():
       Node(value="Nom@fr"),
   ]
   result = extract_name_from_property_with_language(properties, language="de")
-  assert result is None
+  assert result[0] is None
+  assert result[1] is None
 
 
 def test_extract_name_from_property_without_language_tags():
@@ -59,4 +62,5 @@ def test_extract_name_from_property_without_language_tags():
       Node(value="Name@en"),
   ]
   result = extract_name_from_property_with_language(properties, language="en")
-  assert result == "Name"
+  assert result[0] == "Name"
+  assert result[1] == "en"

--- a/datacommons_client/tests/test_names.py
+++ b/datacommons_client/tests/test_names.py
@@ -25,7 +25,7 @@ def test_extract_name_from_property_with_language_match():
   ]
   result = extract_name_from_property_with_language(properties,
                                                     language="es",
-                                                    fallback_to_en=True)
+                                                    fallback_language="en")
   assert result == "Nombre"
 
 
@@ -34,11 +34,12 @@ def test_extract_name_from_property_with_language_fallback():
   properties = [
       Node(value="Name@en"),
       Node(value="Nom@fr"),
+      Node(value="Nome@it"),
   ]
   result = extract_name_from_property_with_language(properties,
                                                     language="de",
-                                                    fallback_to_en=True)
-  assert result == "Name"
+                                                    fallback_language="it")
+  assert result == "Nome"
 
 
 def test_extract_name_from_property_with_language_no_fallback():
@@ -47,9 +48,7 @@ def test_extract_name_from_property_with_language_no_fallback():
       Node(value="Name@en"),
       Node(value="Nom@fr"),
   ]
-  result = extract_name_from_property_with_language(properties,
-                                                    language="de",
-                                                    fallback_to_en=False)
+  result = extract_name_from_property_with_language(properties, language="de")
   assert result is None
 
 
@@ -59,7 +58,5 @@ def test_extract_name_from_property_without_language_tags():
       Node(value="Plain str"),
       Node(value="Name@en"),
   ]
-  result = extract_name_from_property_with_language(properties,
-                                                    language="en",
-                                                    fallback_to_en=False)
+  result = extract_name_from_property_with_language(properties, language="en")
   assert result == "Name"

--- a/datacommons_client/tests/test_names.py
+++ b/datacommons_client/tests/test_names.py
@@ -1,0 +1,65 @@
+from datacommons_client.models.node import Node
+from datacommons_client.utils.names import extract_name_from_english_name_property
+from datacommons_client.utils.names import extract_name_from_property_with_language
+
+
+def test_extract_name_from_english_name_property_with_list():
+  """Test extracting name from a list of Nodes."""
+  properties = [Node(value="Test Name")]
+  result = extract_name_from_english_name_property(properties)
+  assert result == "Test Name"
+
+
+def test_extract_name_from_english_not_list():
+  """Test extracting name from a single Node (not in a list)."""
+  property_node = Node(value="Single Node Name")
+  result = extract_name_from_english_name_property(property_node)
+  assert result == "Single Node Name"
+
+
+def test_extract_name_from_property_with_language_match():
+  """Test extracting name when desired language is present."""
+  properties = [
+      Node(value="Nombre@es"),
+      Node(value="Name@en"),
+  ]
+  result = extract_name_from_property_with_language(properties,
+                                                    language="es",
+                                                    fallback_to_en=True)
+  assert result == "Nombre"
+
+
+def test_extract_name_from_property_with_language_fallback():
+  """Test fallback to English when desired language is not found."""
+  properties = [
+      Node(value="Name@en"),
+      Node(value="Nom@fr"),
+  ]
+  result = extract_name_from_property_with_language(properties,
+                                                    language="de",
+                                                    fallback_to_en=True)
+  assert result == "Name"
+
+
+def test_extract_name_from_property_with_language_no_fallback():
+  """Test no result when language is not found and fallback is disabled."""
+  properties = [
+      Node(value="Name@en"),
+      Node(value="Nom@fr"),
+  ]
+  result = extract_name_from_property_with_language(properties,
+                                                    language="de",
+                                                    fallback_to_en=False)
+  assert result is None
+
+
+def test_extract_name_from_property_without_language_tags():
+  """Test that properties without language tags are skipped."""
+  properties = [
+      Node(value="Plain str"),
+      Node(value="Name@en"),
+  ]
+  result = extract_name_from_property_with_language(properties,
+                                                    language="en",
+                                                    fallback_to_en=False)
+  assert result == "Name"

--- a/datacommons_client/utils/names.py
+++ b/datacommons_client/utils/names.py
@@ -2,6 +2,10 @@ from typing import Optional
 
 from datacommons_client.models.node import Node
 
+DEFAULT_NAME_PROPERTY: str = "name"
+NAME_WITH_LANGUAGE_PROPERTY: str = "nameWithLanguage"
+DEFAULT_NAME_LANGUAGE: str = "en"
+
 
 def extract_name_from_english_name_property(properties: list | Node) -> str:
   """
@@ -18,13 +22,16 @@ def extract_name_from_english_name_property(properties: list | Node) -> str:
 
 
 def extract_name_from_property_with_language(
-    properties: list, language: str, fallback_to_en: bool) -> Optional[str]:
+    properties: list,
+    language: str,
+    fallback_language: Optional[str] = None) -> Optional[str]:
   """
     Extracts the name from a list of properties with language tags.
     Args:
         properties (list): A list of properties with language tags.
         language (str): The desired language code.
-        fallback_to_en (bool): Whether to fall back to English if the desired language is not found.
+        fallback_language: If provided, this language will be used as a fallback if the requested
+            language is not available. If not provided, no fallback will be used.
     """
   # If a non-English language is requested, unpack the response to get it.
   fallback_name = None
@@ -42,9 +49,9 @@ def extract_name_from_property_with_language(
     if lang == language:
       return name
     # If language is 'en', store the name as a fallback
-    if lang == "en":
+    if fallback_language and (lang == fallback_language):
       fallback_name = name
 
   # If no name was found in the specified language, use the fallback name (if available and
   # fallback_to_en is True)
-  return fallback_name if fallback_to_en else None
+  return fallback_name if fallback_language else None

--- a/datacommons_client/utils/names.py
+++ b/datacommons_client/utils/names.py
@@ -1,0 +1,50 @@
+from typing import Optional
+
+from datacommons_client.models.node import Node
+
+
+def extract_name_from_english_name_property(properties: list | Node) -> str:
+  """
+    Extracts the name from a list of properties with English names.
+    Args:
+        properties (list): A list of properties with English names.
+    Returns:
+        str: The extracted name.
+    """
+  if isinstance(properties, Node):
+    properties = [properties]
+
+  return properties[0].value
+
+
+def extract_name_from_property_with_language(
+    properties: list, language: str, fallback_to_en: bool) -> Optional[str]:
+  """
+    Extracts the name from a list of properties with language tags.
+    Args:
+        properties (list): A list of properties with language tags.
+        language (str): The desired language code.
+        fallback_to_en (bool): Whether to fall back to English if the desired language is not found.
+    """
+  # If a non-English language is requested, unpack the response to get it.
+  fallback_name = None
+
+  # Iterate through the properties to find the name in the specified language
+  for candidate in properties:
+    # If no language is specified, skip the candidate
+    if "@" not in candidate.value:
+      continue
+
+    # Split the candidate value into name and language
+    name, lang = candidate.value.rsplit("@", 1)
+
+    # If the language matches, add the name to the dictionary.
+    if lang == language:
+      return name
+    # If language is 'en', store the name as a fallback
+    if lang == "en":
+      fallback_name = name
+
+  # If no name was found in the specified language, use the fallback name (if available and
+  # fallback_to_en is True)
+  return fallback_name if fallback_to_en else None

--- a/datacommons_client/utils/names.py
+++ b/datacommons_client/utils/names.py
@@ -24,7 +24,7 @@ def extract_name_from_english_name_property(properties: list | Node) -> str:
 def extract_name_from_property_with_language(
     properties: list,
     language: str,
-    fallback_language: Optional[str] = None) -> Optional[str]:
+    fallback_language: Optional[str] = None) -> tuple[str | None, str | None]:
   """
     Extracts the name from a list of properties with language tags.
     Args:
@@ -32,6 +32,9 @@ def extract_name_from_property_with_language(
         language (str): The desired language code.
         fallback_language: If provided, this language will be used as a fallback if the requested
             language is not available. If not provided, no fallback will be used.
+
+    Returns:
+        tuple[str,str]: A tuple containing the extracted name and its language.
     """
   # If a non-English language is requested, unpack the response to get it.
   fallback_name = None
@@ -47,11 +50,10 @@ def extract_name_from_property_with_language(
 
     # If the language matches, add the name to the dictionary.
     if lang == language:
-      return name
+      return name, lang
     # If language is 'en', store the name as a fallback
     if fallback_language and (lang == fallback_language):
       fallback_name = name
 
-  # If no name was found in the specified language, use the fallback name (if available and
-  # fallback_to_en is True)
-  return fallback_name if fallback_language else None
+  # If no name was found in the specified language, use the fallback name (if available)
+  return fallback_name, fallback_language if fallback_language else None


### PR DESCRIPTION
This PR is part of a group of PRs which will bring some key features from the Data Commons website API to the client library (e.g #229, #231)

**Fetch entity names**: this is an implementation of a few DC website features:
- The name endpoint of the [internal API](https://github.com/datacommonsorg/website/blob/master/server/routes/shared_api/place.py#L158-L171). `/api/place/name`
- The [internal code](https://github.com/datacommonsorg/website/blob/master/server/lib/shared.py#L22-L55) to fetch the english names from the `name` property.
- The [internal code](https://github.com/datacommonsorg/website/blob/master/server/routes/shared_api/place.py#L174-L213) to fetch the i18n name using the `nameWithLanguage` property (the website automatically resolves the user's locale, this method takes it as an argument)

In short, this PR:
- Adds a `fetch_entity_names` method to `NodeEndpoint`. This method takes one or more `entity_dcids` and fetches their name. It defaults to English, but other languages (`fr`, `es`, etc) can be selected using the optional `language` argument. Optionally, users can request to fallback to a particular language if the requested language is not available (to avoid sparse results in some languages).

Example usage:

```python

from datacommons_client import DataCommonsClient

dc = DataCommonsClient(dc_instance="datacommons.one.org")

names = dc.node.fetch_entity_names(
    entity_dcids=[
        "africa",
        "country/GTM",
        "country/USA",
        "wikidataId/Q2608785",
    ],
    language="de",
)


{'africa': 'Afrika',
 'country/GTM': 'Guatemala',
 'country/USA': 'Vereinigte Staaten'}
```

And with the optional fallback to english:
```python
names = dc.node.fetch_entity_names(
    entity_dcids=[
        "africa",
        "country/GTM",
        "country/USA",
        "wikidataId/Q2608785",
    ],
    language="de",
    fallback_language="en",
)

{'africa': 'Afrika',
 'country/GTM': 'Guatemala',
 'country/USA': 'Vereinigte Staaten',
 'wikidataId/Q2608785': 'La Democracia'}

```

In the background, this method uses `name` or `nameWithLanguage` depending on what the user requests. `name` is much cheaper than `nameWithLanguage` since it only contains one value per entity. The method only requests and parses `nameWithLanguage` if a non-english language is selected.

A previous version used english as the fallback, available via a boolean. The latest version implements a more generic, Optional, `fallback_language` which takes a string (default to `None` for no fallback)

