### PR TITLE
bug: fix arc unpacking

### DIFF
--- a/datacommons_client/tests/endpoints/test_response.py
+++ b/datacommons_client/tests/endpoints/test_response.py
@@ -183,6 +183,24 @@ def test_flatten_arcs():
   assert result["dc/03lw9rhpendw5"].value == "191 Peachtree Tower"
 
 
+def test_unpack_arcs_missing_nodes_key():
+  """Test that unpack_arcs handles arcs with no 'nodes' key."""
+  arcs = {
+      "prop1": {
+          "nodes": ["node1", "node2"]
+      },
+      "prop2": {
+          # No 'nodes' key here
+      },
+      "prop3": {
+          "nodes": []
+      },
+  }
+
+  result = unpack_arcs(arcs)
+  assert result == {"prop1": ["node1", "node2"], "prop2": None, "prop3": []}
+
+
 def test_unpack_arcs_multiple_properties():
   """Test that _unpack_arcs correctly handles multiple properties with nodes."""
   arcs = {

--- a/datacommons_client/tests/endpoints/test_response.py
+++ b/datacommons_client/tests/endpoints/test_response.py
@@ -198,7 +198,7 @@ def test_unpack_arcs_missing_nodes_key():
   }
 
   result = unpack_arcs(arcs)
-  assert result == {"prop1": ["node1", "node2"], "prop2": None, "prop3": []}
+  assert result == {"prop1": ["node1", "node2"], "prop2": [], "prop3": []}
 
 
 def test_unpack_arcs_multiple_properties():

--- a/datacommons_client/utils/data_processing.py
+++ b/datacommons_client/utils/data_processing.py
@@ -7,7 +7,7 @@ def unpack_arcs(arcs: Dict[str, Any]) -> Any:
   """Simplify the 'arcs' structure."""
   if len(arcs) > 1:
     # Multiple arcs: return dictionary of property nodes
-    return {prop: arc_data.get("nodes") for prop, arc_data in arcs.items()}
+    return {prop: arc_data.get("nodes", []) for prop, arc_data in arcs.items()}
 
   # Single arc: extract first node's data
   for property_data in arcs.values():

--- a/datacommons_client/utils/data_processing.py
+++ b/datacommons_client/utils/data_processing.py
@@ -7,7 +7,7 @@ def unpack_arcs(arcs: Dict[str, Any]) -> Any:
   """Simplify the 'arcs' structure."""
   if len(arcs) > 1:
     # Multiple arcs: return dictionary of property nodes
-    return {prop: arc_data["nodes"] for prop, arc_data in arcs.items()}
+    return {prop: arc_data.get("nodes") for prop, arc_data in arcs.items()}
 
   # Single arc: extract first node's data
   for property_data in arcs.values():


### PR DESCRIPTION
Fixes a bug caused when the arc does not contain `nodes`.  It was returning a `TypeError: 'NodeGroup' object is not subscriptable`.

With this PR the behaviour is consistent and an empty list is returned instead.

Also added a test for this specific case.

