### PR TITLE
Remove auto-flattening for unpack_arcs.

### DIFF
--- a/datacommons_client/tests/endpoints/test_response.py
+++ b/datacommons_client/tests/endpoints/test_response.py
@@ -182,7 +182,11 @@ def test_flatten_arcs():
   result = flatten_properties(response.data)
 
   assert "dc/03lw9rhpendw5" in result
-  assert result["dc/03lw9rhpendw5"].value == "191 Peachtree Tower"
+  assert result["dc/03lw9rhpendw5"] == {
+      "name": [
+          Node(value="191 Peachtree Tower", provenanceId="dc/base/EIA_860")
+      ]
+  }
 
 
 def test_flatten_multiple_arcs_with_multiple_nodes():

--- a/datacommons_client/utils/data_processing.py
+++ b/datacommons_client/utils/data_processing.py
@@ -21,7 +21,8 @@ def unpack_arcs(arcs: Dict[ArcLabel, NodeGroup]) -> Dict[Property, List[Node]]:
 
 
 def flatten_properties(
-    data: Dict[NodeDCID, Arcs | Properties]) -> Dict[str, Any]:
+    data: Dict[NodeDCID, Arcs | Properties]
+) -> Dict[NodeDCID, List[Property] | Dict[Property, List[Node]]]:
   """
     Flatten the properties of a node response.
 

--- a/datacommons_client/utils/data_processing.py
+++ b/datacommons_client/utils/data_processing.py
@@ -1,27 +1,23 @@
 from dataclasses import asdict
 import json
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from datacommons_client.models.node import ArcLabel
 from datacommons_client.models.node import Arcs
 from datacommons_client.models.node import Name
+from datacommons_client.models.node import Node
 from datacommons_client.models.node import NodeDCID
 from datacommons_client.models.node import NodeGroup
 from datacommons_client.models.node import Properties
+from datacommons_client.models.node import Property
 
 
-def unpack_arcs(arcs: Dict[ArcLabel, NodeGroup]) -> Any:
+def unpack_arcs(arcs: Dict[ArcLabel, NodeGroup]) -> Dict[Property, List[Node]]:
   """Simplify the 'arcs' structure."""
-  if len(arcs) > 1:
-    # Multiple arcs: return dictionary of property nodes
-    return {
-        prop: getattr(arc_data, "nodes", []) for prop, arc_data in arcs.items()
-    }
-  # Single arc: extract first node's data
-  for property_data in arcs.values():
-    nodes = property_data.nodes
-    if nodes is not None:
-      return nodes if len(nodes) > 1 else nodes[0]
+  # Return dictionary of property nodes
+  return {
+      prop: getattr(arc_data, "nodes", []) for prop, arc_data in arcs.items()
+  }
 
 
 def flatten_properties(


### PR DESCRIPTION
Currently the auto-flattening of unpack_arcs leads to the following scenario:

Two properties are requested for a given entity but data only exists for one of the properties. The REST api will not contain the property with no data in the response, therefore we cannot tell **from only the response** the difference between one property requested and one property out of multiple properties requested contains data.

An example:
```
node_resp = dc_client.node.fetch(node_dcids="bio/APOE", expression="<-[encodesGene,variantID]")
node_resp.get_properties()
> {'bio/APOE': [Node(dcid='bio/AB035149.1', name='AB035149.1', provenanceId='dc/base/NCBI_Gene'...), ...] ...}
```

In the response from get_properties(), we can't tell if it's for encodesGene or variantID.

A long term fix for this would be to store the original requested properties in the NodeResponse object and only do this "autoflattening" when there was one **requested** property. However, another consideration is that many return types for a single method can cause a lot confusion.