### PR TITLE
Add children / descendants methods 

### DIFF
--- a/datacommons_client/endpoints/node.py
+++ b/datacommons_client/endpoints/node.py
@@ -297,15 +297,12 @@ class NodeEndpoint(Endpoint):
       self,
       entity_dcids: str | list[str],
       *,
-      parent_type: Optional[str] = None,
       as_dict: bool = True,
   ) -> dict[str, list[Node | dict]]:
     """Fetches the direct parents of one or more entities using the 'containedInPlace' property.
 
         Args:
             entity_dcids (str | list[str]): A single DCID or a list of DCIDs to query.
-            parent_type (str, optional): The type of the parent entities to
-                fetch (e.g., 'Country', 'State', 'IPCCPlace_50'). If None, fetches all child types.
             as_dict (bool): If True, returns a dictionary mapping each input DCID to its
                 immediate parent entities. If False, returns a dictionary of Node objects.
 
@@ -317,7 +314,7 @@ class NodeEndpoint(Endpoint):
     return self._fetch_contained_in_place(
         node_dcids=entity_dcids,
         out=True,
-        contained_type=parent_type,
+        contained_type=None,
         as_dict=as_dict,
     )
 
@@ -415,7 +412,6 @@ class NodeEndpoint(Endpoint):
       self,
       entity_dcids: str | list[str],
       as_tree: bool = False,
-      ancestry_type: Optional[str] = None,
       *,
       max_concurrent_requests: Optional[int] = ANCESTRY_MAX_WORKERS,
   ) -> dict[str, list[dict[str, str]] | dict]:
@@ -430,8 +426,6 @@ class NodeEndpoint(Endpoint):
                will be fetched.
             as_tree (bool): If True, returns a nested tree structure; otherwise, returns a flat list.
                 Defaults to False.
-            ancestry_type (Optional[str]): The type of the ancestry to fetch (e.g., 'Country', 'State').
-                If None, fetches all ancestry types.
             max_concurrent_requests (Optional[int]): The maximum number of concurrent requests to make.
                 Defaults to ANCESTRY_MAX_WORKERS.
         Returns:
@@ -444,7 +438,7 @@ class NodeEndpoint(Endpoint):
     return self._fetch_entity_relationships(
         entity_dcids=entity_dcids,
         as_tree=as_tree,
-        contained_type=ancestry_type,
+        contained_type=None,
         relationship="parents",
         max_concurrent_requests=max_concurrent_requests,
     )

--- a/datacommons_client/endpoints/node.py
+++ b/datacommons_client/endpoints/node.py
@@ -288,7 +288,7 @@ class NodeEndpoint(Endpoint):
     if as_dict:
       for entity, nodes in data.items():
         if not nodes:
-            continue
+          continue
         if isinstance(nodes, Node):
           return {entity: [nodes.to_dict()]}
         else:

--- a/datacommons_client/endpoints/node.py
+++ b/datacommons_client/endpoints/node.py
@@ -296,16 +296,16 @@ class NodeEndpoint(Endpoint):
 
     return result
 
-  def fetch_entity_parents(
+  def fetch_place_parents(
       self,
-      entity_dcids: str | list[str],
+      place_dcids: str | list[str],
       *,
       as_dict: bool = True,
   ) -> dict[str, list[Node | dict]]:
     """Fetches the direct parents of one or more entities using the 'containedInPlace' property.
 
         Args:
-            entity_dcids (str | list[str]): A single DCID or a list of DCIDs to query.
+            place_dcids (str | list[str]): A single place DCID or a list of DCIDs to query.
             as_dict (bool): If True, returns a dictionary mapping each input DCID to its
                 immediate parent entities. If False, returns a dictionary of Node objects.
 
@@ -315,15 +315,15 @@ class NodeEndpoint(Endpoint):
             as a dictionary with the same data.
         """
     return self._fetch_contained_in_place(
-        node_dcids=entity_dcids,
+        node_dcids=place_dcids,
         out=True,
         contained_type=None,
         as_dict=as_dict,
     )
 
-  def fetch_entity_children(
+  def fetch_place_children(
       self,
-      entity_dcids: str | list[str],
+      place_dcids: str | list[str],
       *,
       children_type: Optional[str] = None,
       as_dict: bool = True,
@@ -331,7 +331,7 @@ class NodeEndpoint(Endpoint):
     """Fetches the direct children of one or more entities using the 'containedInPlace' property.
 
         Args:
-            entity_dcids (str | list[str]): A single DCID or a list of DCIDs to query.
+            place_dcids (str | list[str]): A single place DCID or a list of DCIDs to query.
             children_type (str, optional): The type of the child entities to
                 fetch (e.g., 'Country', 'State', 'IPCCPlace_50'). If None, fetches all child types.
             as_dict (bool): If True, returns a dictionary mapping each input DCID to its
@@ -343,28 +343,28 @@ class NodeEndpoint(Endpoint):
             the same data.
         """
     return self._fetch_contained_in_place(
-        node_dcids=entity_dcids,
+        node_dcids=place_dcids,
         out=False,
         contained_type=children_type,
         as_dict=as_dict,
     )
 
-  def _fetch_entity_relationships(
+  def _fetch_place_relationships(
       self,
-      entity_dcids: str | list[str],
+      place_dcids: str | list[str],
       as_tree: bool = False,
       *,
       contained_type: Optional[str] = None,
       relationship: Literal["parents", "children"],
       max_concurrent_requests: Optional[int] = ANCESTRY_MAX_WORKERS,
   ) -> dict[str, list[dict[str, str]] | dict]:
-    """Fetches a full ancestry/descendancy map per DCID.
+    """Fetches a full ancestry/descendancy map per place DCID.
 
-        For each input DCID, this method builds the complete graph using a
+        For each input place DCID, this method builds the complete graph using a
         breadth-first traversal and parallel fetching.
 
         Args:
-            entity_dcids (str | list[str]): One or more DCIDs of the entities whose ancestry
+            place_dcids (str | list[str]): One or more DCIDs of the entities whose ancestry
                will be fetched.
             as_tree (bool): If True, returns a nested tree structure; otherwise, returns a flat list.
                 Defaults to False.
@@ -379,8 +379,8 @@ class NodeEndpoint(Endpoint):
                 - A nested tree (if `as_tree` is True).
         """
 
-    if isinstance(entity_dcids, str):
-      entity_dcids = [entity_dcids]
+    if isinstance(place_dcids, str):
+      place_dcids = [place_dcids]
 
     result = {}
 
@@ -396,7 +396,7 @@ class NodeEndpoint(Endpoint):
     with ThreadPoolExecutor(max_workers=max_concurrent_requests) as executor:
       futures = [
           executor.submit(build_graph_map, root=dcid, fetch_fn=fetch_fn)
-          for dcid in entity_dcids
+          for dcid in place_dcids
       ]
       # Gather ancestry maps and postprocess into flat or nested form
       for future in futures:
@@ -411,9 +411,9 @@ class NodeEndpoint(Endpoint):
 
     return result
 
-  def fetch_entity_ancestry(
+  def fetch_place_ancestry(
       self,
-      entity_dcids: str | list[str],
+      place_dcids: str | list[str],
       as_tree: bool = False,
       *,
       max_concurrent_requests: Optional[int] = ANCESTRY_MAX_WORKERS,
@@ -425,7 +425,7 @@ class NodeEndpoint(Endpoint):
         each entity, depending on the `as_tree` flag. The flat list matches the structure
         of the `/api/place/parent` endpoint of the DC website.
         Args:
-            entity_dcids (str | list[str]): One or more DCIDs of the entities whose ancestry
+            place_dcids (str | list[str]): One or more DCIDs of the entities whose ancestry
                will be fetched.
             as_tree (bool): If True, returns a nested tree structure; otherwise, returns a flat list.
                 Defaults to False.
@@ -438,17 +438,17 @@ class NodeEndpoint(Endpoint):
                   a dict with 'dcid', 'name', and 'type'.
         """
 
-    return self._fetch_entity_relationships(
-        entity_dcids=entity_dcids,
+    return self._fetch_place_relationships(
+        place_dcids=place_dcids,
         as_tree=as_tree,
         contained_type=None,
         relationship="parents",
         max_concurrent_requests=max_concurrent_requests,
     )
 
-  def fetch_entity_descendancy(
+  def fetch_place_descendancy(
       self,
-      entity_dcids: str | list[str],
+      place_dcids: str | list[str],
       descendants_type: Optional[str] = None,
       as_tree: bool = False,
       *,
@@ -462,7 +462,7 @@ class NodeEndpoint(Endpoint):
         each entity, depending on the `as_tree` flag.
 
         Args:
-            entity_dcids (str | list[str]): One or more DCIDs of the entities whose descendants
+            place_dcids (str | list[str]): One or more DCIDs of the entities whose descendants
                will be fetched.
             descendants_type (Optional[str]): The type of the descendants to fetch (e.g., 'Country', 'State').
                 If None, fetches all descendant types.
@@ -477,8 +477,8 @@ class NodeEndpoint(Endpoint):
                   a dict.
         """
 
-    return self._fetch_entity_relationships(
-        entity_dcids=entity_dcids,
+    return self._fetch_place_relationships(
+        place_dcids=place_dcids,
         as_tree=as_tree,
         contained_type=descendants_type,
         relationship="children",

--- a/datacommons_client/endpoints/node.py
+++ b/datacommons_client/endpoints/node.py
@@ -287,6 +287,8 @@ class NodeEndpoint(Endpoint):
 
     if as_dict:
       for entity, nodes in data.items():
+        if not nodes:
+            continue
         if isinstance(nodes, Node):
           return {entity: [nodes.to_dict()]}
         else:

--- a/datacommons_client/endpoints/node.py
+++ b/datacommons_client/endpoints/node.py
@@ -19,7 +19,7 @@ from datacommons_client.utils.names import extract_name_from_english_name_proper
 from datacommons_client.utils.names import extract_name_from_property_with_language
 from datacommons_client.utils.names import NAME_WITH_LANGUAGE_PROPERTY
 
-ANCESTRY_MAX_WORKERS = 10
+PLACES_MAX_WORKERS = 10
 
 
 class NodeEndpoint(Endpoint):
@@ -356,9 +356,9 @@ class NodeEndpoint(Endpoint):
       *,
       contained_type: Optional[str] = None,
       relationship: Literal["parents", "children"],
-      max_concurrent_requests: Optional[int] = ANCESTRY_MAX_WORKERS,
+      max_concurrent_requests: Optional[int] = PLACES_MAX_WORKERS,
   ) -> dict[str, list[dict[str, str]] | dict]:
-    """Fetches a full ancestry/descendancy map per place DCID.
+    """Fetches a full ancestors/descendants map per place DCID.
 
         For each input place DCID, this method builds the complete graph using a
         breadth-first traversal and parallel fetching.
@@ -372,7 +372,7 @@ class NodeEndpoint(Endpoint):
                 If None, fetches all ancestry types.
             relationship (Literal["parents", "children"]): The type of relationship to fetch.
             max_concurrent_requests (Optional[int]): The maximum number of concurrent requests to make.
-                Defaults to ANCESTRY_MAX_WORKERS.
+                Defaults to PLACES_MAX_WORKERS.
         Returns:
             dict[str, list[dict[str, str]] | dict]: A dictionary mapping each input DCID to either:
                 - A flat list of Node dictionaries (if `as_tree` is False), or
@@ -411,12 +411,12 @@ class NodeEndpoint(Endpoint):
 
     return result
 
-  def fetch_place_ancestry(
+  def fetch_place_ancestors(
       self,
       place_dcids: str | list[str],
       as_tree: bool = False,
       *,
-      max_concurrent_requests: Optional[int] = ANCESTRY_MAX_WORKERS,
+      max_concurrent_requests: Optional[int] = PLACES_MAX_WORKERS,
   ) -> dict[str, list[dict[str, str]] | dict]:
     """Fetches the full ancestry (flat or nested) for one or more entities.
         For each input DCID, this method builds the complete ancestry graph using a
@@ -430,7 +430,7 @@ class NodeEndpoint(Endpoint):
             as_tree (bool): If True, returns a nested tree structure; otherwise, returns a flat list.
                 Defaults to False.
             max_concurrent_requests (Optional[int]): The maximum number of concurrent requests to make.
-                Defaults to ANCESTRY_MAX_WORKERS.
+                Defaults to PLACES_MAX_WORKERS.
         Returns:
             dict[str, list[dict[str, str]] | dict]: A dictionary mapping each input DCID to either:
                 - A flat list of parent dictionaries (if `as_tree` is False), or
@@ -446,13 +446,13 @@ class NodeEndpoint(Endpoint):
         max_concurrent_requests=max_concurrent_requests,
     )
 
-  def fetch_place_descendancy(
+  def fetch_place_descendants(
       self,
       place_dcids: str | list[str],
       descendants_type: Optional[str] = None,
       as_tree: bool = False,
       *,
-      max_concurrent_requests: Optional[int] = ANCESTRY_MAX_WORKERS,
+      max_concurrent_requests: Optional[int] = PLACES_MAX_WORKERS,
   ) -> dict[str, list[dict[str, str]] | dict]:
     """Fetches the full descendants (flat or nested) for one or more entities.
         For each input DCID, this method builds the complete descendants graph using a
@@ -469,7 +469,7 @@ class NodeEndpoint(Endpoint):
             as_tree (bool): If True, returns a nested tree structure; otherwise, returns a flat list.
                 Defaults to False.
             max_concurrent_requests (Optional[int]): The maximum number of concurrent requests to make.
-                Defaults to ANCESTRY_MAX_WORKERS.
+                Defaults to PLACES_MAX_WORKERS.
         Returns:
             dict[str, list[dict[str, str]] | dict]: A dictionary mapping each input DCID to either:
                 - A flat list of Node dictionaries (if `as_tree` is False), or

--- a/datacommons_client/tests/endpoints/test_node_endpoint.py
+++ b/datacommons_client/tests/endpoints/test_node_endpoint.py
@@ -346,12 +346,10 @@ def test_fetch_entity_relationships_delegates_to_lru(mock_lru, mock_build_map,
   mock_flatten.return_value = []
 
   endpoint = NodeEndpoint(api=MagicMock())
-  result = endpoint._fetch_entity_relationships(
-      entity_dcids="X",
-      as_tree=False,
-      contained_type="Region",
-      relationship="parents",
-  )
+  result = endpoint._fetch_place_relationships(place_dcids="X",
+                                               as_tree=False,
+                                               contained_type="Region",
+                                               relationship="parents")
 
   assert result == {"X": []}
   mock_lru.assert_called_once_with(
@@ -380,7 +378,7 @@ def test_fetch_entity_ancestry_flat(mock_build_map, mock_flatten):
   }]
 
   endpoint = NodeEndpoint(api=MagicMock())
-  result = endpoint.fetch_entity_ancestry("X", as_tree=False)
+  result = endpoint.fetch_place_ancestry("X", as_tree=False)
 
   assert result == {"X": [{"dcid": "A", "name": "A name", "type": "Country"}]}
   mock_build_map.assert_called_once()
@@ -416,7 +414,7 @@ def test_fetch_entity_ancestry_tree(mock_build_map, mock_build_tree):
   }
 
   endpoint = NodeEndpoint(api=MagicMock())
-  result = endpoint.fetch_entity_ancestry("Y", as_tree=True)
+  result = endpoint.fetch_place_ancestry("Y", as_tree=True)
 
   assert "Y" in result
   assert result["Y"]["dcid"] == "Y"

--- a/datacommons_client/tests/endpoints/test_node_endpoint.py
+++ b/datacommons_client/tests/endpoints/test_node_endpoint.py
@@ -378,7 +378,7 @@ def test_fetch_entity_ancestry_flat(mock_build_map, mock_flatten):
   }]
 
   endpoint = NodeEndpoint(api=MagicMock())
-  result = endpoint.fetch_place_ancestry("X", as_tree=False)
+  result = endpoint.fetch_place_ancestors("X", as_tree=False)
 
   assert result == {"X": [{"dcid": "A", "name": "A name", "type": "Country"}]}
   mock_build_map.assert_called_once()
@@ -414,7 +414,7 @@ def test_fetch_entity_ancestry_tree(mock_build_map, mock_build_tree):
   }
 
   endpoint = NodeEndpoint(api=MagicMock())
-  result = endpoint.fetch_place_ancestry("Y", as_tree=True)
+  result = endpoint.fetch_place_ancestors("Y", as_tree=True)
 
   assert "Y" in result
   assert result["Y"]["dcid"] == "Y"

--- a/datacommons_client/tests/endpoints/test_node_endpoint.py
+++ b/datacommons_client/tests/endpoints/test_node_endpoint.py
@@ -327,26 +327,49 @@ def test_fetch_entity_names_no_result(mock_extract_name_lang):
   assert result == {}
 
 
-@patch("datacommons_client.endpoints.node.fetch_parents_lru")
-def test_fetch_parents_cached_delegates_to_lru(mock_fetch_lru):
-  mock_fetch_lru.return_value = (Node("B", "B name", "Region"),)
+@patch("datacommons_client.endpoints.node.flatten_relationship")
+@patch("datacommons_client.endpoints.node.build_graph_map")
+@patch("datacommons_client.endpoints.node.fetch_relationship_lru")
+def test_fetch_entity_relationships_delegates_to_lru(mock_lru, mock_build_map,
+                                                     mock_flatten):
+  """Ensure that the private helper builds a fetch‑function that ultimately
+    calls through to ``fetch_relationship_lru`` for each root DCID."""
+
+  mock_lru.return_value = [Node("B", "B name", ["Region"])]
+
+  def _fake_build_graph_map(root, fetch_fn):
+    # simulate the internal traversal by invoking the provided fetch_fn once
+    fetch_fn(dcid=root)
+    return root, {}
+
+  mock_build_map.side_effect = _fake_build_graph_map
+  mock_flatten.return_value = []
+
   endpoint = NodeEndpoint(api=MagicMock())
+  result = endpoint._fetch_entity_relationships(
+      entity_dcids="X",
+      as_tree=False,
+      contained_type="Region",
+      relationship="parents",
+  )
 
-  result = endpoint._fetch_parents_cached("X")
+  assert result == {"X": []}
+  mock_lru.assert_called_once_with(
+      endpoint,
+      dcid="X",
+      contained_type="Region",
+      relationship="parents",
+  )
 
-  assert isinstance(result, tuple)
-  assert result[0].dcid == "B"
-  mock_fetch_lru.assert_called_once_with(endpoint, "X")
 
-
-@patch("datacommons_client.endpoints.node.flatten_ancestry")
-@patch("datacommons_client.endpoints.node.build_ancestry_map")
+@patch("datacommons_client.endpoints.node.flatten_relationship")
+@patch("datacommons_client.endpoints.node.build_graph_map")
 def test_fetch_entity_ancestry_flat(mock_build_map, mock_flatten):
-  """Test fetch_entity_ancestry with flat structure (as_tree=False)."""
+  """Flat ancestry structure should be derived via ``flatten_relationship``."""
   mock_build_map.return_value = (
       "X",
       {
-          "X": [Node("A", "A name", "Country")],
+          "X": [Node("A", "A name", ["Country"])],
           "A": [],
       },
   )
@@ -364,17 +387,19 @@ def test_fetch_entity_ancestry_flat(mock_build_map, mock_flatten):
   mock_flatten.assert_called_once()
 
 
-@patch("datacommons_client.endpoints.node.build_ancestry_tree")
-@patch("datacommons_client.endpoints.node.build_ancestry_map")
+@patch("datacommons_client.endpoints.node.build_relationship_tree")
+@patch("datacommons_client.endpoints.node.build_graph_map")
 def test_fetch_entity_ancestry_tree(mock_build_map, mock_build_tree):
-  """Test fetch_entity_ancestry with tree structure (as_tree=True)."""
+  """Nested ancestry structure should be derived via
+    ``build_relationship_tree``."""
   mock_build_map.return_value = (
       "Y",
       {
-          "Y": [Node("Z", "Z name", "Region")],
+          "Y": [Node("Z", "Z name", ["Region"])],
           "Z": [],
       },
   )
+
   mock_build_tree.return_value = {
       "dcid":
           "Y",
@@ -397,4 +422,6 @@ def test_fetch_entity_ancestry_tree(mock_build_map, mock_build_tree):
   assert result["Y"]["dcid"] == "Y"
   assert result["Y"]["parents"][0]["dcid"] == "Z"
   mock_build_map.assert_called_once()
-  mock_build_tree.assert_called_once_with("Y", mock_build_map.return_value[1])
+  mock_build_tree.assert_called_once_with(root="Y",
+                                          graph=mock_build_map.return_value[1],
+                                          relationship_key="parents")

--- a/datacommons_client/tests/utils/test_graph.py
+++ b/datacommons_client/tests/utils/test_graph.py
@@ -24,9 +24,10 @@ def test_fetch_parents_uncached_returns_data():
                                         relationship="parents")
   assert isinstance(result, list)
   assert result[0].dcid == "parent1"
-  endpoint.fetch_entity_parents.assert_called_once_with("test_dcid",
-                                                        as_dict=False,
-                                                        parent_type=None)
+  endpoint.fetch_entity_parents.assert_called_once_with(
+      "test_dcid",
+      as_dict=False,
+  )
 
 
 def test_fetch_relationship_lru_caches_results():

--- a/datacommons_client/tests/utils/test_graph.py
+++ b/datacommons_client/tests/utils/test_graph.py
@@ -14,7 +14,7 @@ from datacommons_client.utils.graph import flatten_relationship
 def test_fetch_parents_uncached_returns_data():
   """Test _fetch_parents_uncached delegates to endpoint correctly."""
   endpoint = MagicMock()
-  endpoint.fetch_entity_parents.return_value.get.return_value = [
+  endpoint.fetch_place_parents.return_value.get.return_value = [
       Node(dcid="parent1", name="Parent 1", types=["Country"])
   ]
 
@@ -24,7 +24,7 @@ def test_fetch_parents_uncached_returns_data():
                                         relationship="parents")
   assert isinstance(result, list)
   assert result[0].dcid == "parent1"
-  endpoint.fetch_entity_parents.assert_called_once_with(
+  endpoint.fetch_place_parents.assert_called_once_with(
       "test_dcid",
       as_dict=False,
   )
@@ -33,7 +33,7 @@ def test_fetch_parents_uncached_returns_data():
 def test_fetch_relationship_lru_caches_results():
   """Test fetch_relationship_lru uses LRU cache and returns list."""
   endpoint = MagicMock()
-  endpoint.fetch_entity_parents.return_value.get.return_value = [
+  endpoint.fetch_place_parents.return_value.get.return_value = [
       Node(dcid="parentX", name="Parent X", types=["Region"])
   ]
 
@@ -53,7 +53,7 @@ def test_fetch_relationship_lru_caches_results():
   assert isinstance(result1, list)
   assert result1[0].dcid == "parentX"
   assert result1 == result2
-  assert endpoint.fetch_entity_parents.call_count == 1
+  assert endpoint.fetch_place_parents.call_count == 1
 
 
 def test_build_ancestry_map_linear_tree():

--- a/datacommons_client/utils/graph.py
+++ b/datacommons_client/utils/graph.py
@@ -11,8 +11,8 @@ from datacommons_client.models.node import Node
 GRAPH_MAX_WORKERS = 10
 
 RelationMap: TypeAlias = dict[str, list[Node]]
-AncestryMap = RelationMap
-DescendancyMap = RelationMap
+AncestorsMap = RelationMap
+DescendantsMap = RelationMap
 
 # -- -- Fetch tools -- --
 

--- a/datacommons_client/utils/graph.py
+++ b/datacommons_client/utils/graph.py
@@ -42,10 +42,7 @@ def _fetch_relationship_uncached(
     """
 
   if relationship == "parents":
-    result = endpoint.fetch_entity_parents(dcid,
-                                           as_dict=False,
-                                           parent_type=contained_type).get(
-                                               dcid, [])
+    result = endpoint.fetch_entity_parents(dcid, as_dict=False).get(dcid, [])
 
   else:
     result = endpoint.fetch_entity_children(dcid,

--- a/datacommons_client/utils/graph.py
+++ b/datacommons_client/utils/graph.py
@@ -42,13 +42,12 @@ def _fetch_relationship_uncached(
     """
 
   if relationship == "parents":
-    result = endpoint.fetch_entity_parents(dcid, as_dict=False).get(dcid, [])
+    result = endpoint.fetch_place_parents(dcid, as_dict=False).get(dcid, [])
 
   else:
-    result = endpoint.fetch_entity_children(dcid,
-                                            as_dict=False,
-                                            children_type=contained_type).get(
-                                                dcid, [])
+    result = endpoint.fetch_place_children(dcid,
+                                           children_type=contained_type,
+                                           as_dict=False).get(dcid, [])
 
   return result if isinstance(result, list) else [result]
 


### PR DESCRIPTION
TL;DR: This PR refactors the ascendency features in order to work for children/descendants as well.

This creates convenient ways to fetch parents and children of given entities. This can be done for the immediate cases, or recursively up and down the graph.

`fetch_entity_children` takes one or more entity dcids and fetches its children via the `containedInPlace`. It optionally accepts `children_type` which gets only children of a specific type (e.g., 'Country', 'State', 'IPCCPlace_50')

`fetch_entity_descendancy` is a similar method, but it does so via BFS recursively. It is highly recommended to specify a type in that case, as otherwise the search can become extremely large for entities further up in the graph.

This PR was inspired by #238 by @clincoln8, though it does not address the same exact concerns.


**Example 1** - Get parents

```python
from datacommons_client import DataCommonsClient

dc = DataCommonsClient(dc_instance="datacommons.one.org")

parents = dc.node.fetch_place_parents("country/GTM")

{'country/GTM': [{'dcid': 'CentralAmerica',
                  'name': 'Central America (including Mexico)',
                  'provenanceId': 'dc/base/WikidataOtherIdGeos',
                  'types': ['UNGeoRegion']},
                 {'dcid': 'LatinAmericaAndCaribbean',
                  'name': 'Latin America and the Caribbean',
                  'provenanceId': 'dc/base/WikidataOtherIdGeos',
                  'types': ['UNGeoRegion']},
                 {'dcid': 'northamerica',
                  'name': 'North America',
                  'provenanceId': 'dc/base/WikidataOtherIdGeos',
                  'types': ['Continent']},
                 {'dcid': 'undata-geo/G00134000',
                  'name': 'Americas',
                  'provenanceId': 'dc/base/WikidataOtherIdGeos',
                  'types': ['GeoRegion']}]}
```

**Example 2** - Get ancestry

```python
ancestry = dc.node.fetch_place_ancestors("country/GTM")

{'country/GTM': [{'dcid': 'CentralAmerica',
                  'name': 'Central America (including Mexico)',
                  'provenanceId': 'dc/base/WikidataOtherIdGeos',
                  'types': ['UNGeoRegion']},
                 {'dcid': 'LatinAmericaAndCaribbean',
                  'name': 'Latin America and the Caribbean',
                  'provenanceId': 'dc/base/WikidataOtherIdGeos',
                  'types': ['UNGeoRegion']},
                 {'dcid': 'northamerica',
                  'name': 'North America',
                  'provenanceId': 'dc/base/WikidataOtherIdGeos',
                  'types': ['Continent']},
                 {'dcid': 'undata-geo/G00134000',
                  'name': 'Americas',
                  'provenanceId': 'dc/base/WikidataOtherIdGeos',
                  'types': ['GeoRegion']},
                 {'dcid': 'Earth',
                  'name': 'World',
                  'provenanceId': 'dc/base/BaseGeos',
                  'types': ['Place']}]}

```

**Note**: I think it should be possible to specify an ancestry type. But it doesn't seem supported by the REST API:
```bash
Response: {"code":3,"message":"Invalid property containedInPlace for wildcard '+'"}
```

**Example 3** get children, specifying a type. If no type is specified, all are fetched (in this case 1300+)

```python
from datacommons_client import DataCommonsClient

dc = DataCommonsClient(dc_instance="datacommons.one.org")

children = dc.node.fetch_place_children(
    "country/GTM", children_type="AdministrativeArea1"
)

{'country/GTM': [{'dcid': 'wikidataId/Q178136', 'name': 'Sololá Department'},
                 {'dcid': 'wikidataId/Q21296012',
                  'name': 'Amatitlán Department'},
                 {'dcid': 'wikidataId/Q466061', 'name': 'Petén Department'},
                 {'dcid': 'wikidataId/Q504637',
                  'name': 'Alta Verapaz Department'},
                 {'dcid': 'wikidataId/Q504647',
                  'name': 'Baja Verapaz Department'},
                 {'dcid': 'wikidataId/Q508804',
                  'name': 'Sacatepéquez Department'},
                 {'dcid': 'wikidataId/Q669802', 'name': 'Quiché Department'},
                 {'dcid': 'wikidataId/Q693658', 'name': 'Izabal Department'},
                 {'dcid': 'wikidataId/Q695660', 'name': 'Guatemala Department'},
                 {'dcid': 'wikidataId/Q753037',
                  'name': 'Chiquimula Department'},
                 {'dcid': 'wikidataId/Q765975',
                  'name': 'Chimaltenango Department'},
                 {'dcid': 'wikidataId/Q765984', 'name': 'Jutiapa Department'},
                 {'dcid': 'wikidataId/Q780784', 'name': 'Zacapa Department'},
                 {'dcid': 'wikidataId/Q795441', 'name': 'Jalapa Department'},
                 {'dcid': 'wikidataId/Q795587', 'name': 'Escuintla Department'},
                 {'dcid': 'wikidataId/Q795591',
                  'name': 'El Progreso Department'},
                 {'dcid': 'wikidataId/Q842266',
                  'name': 'Huehuetenango Department'},
                 {'dcid': 'wikidataId/Q844502',
                  'name': 'Quetzaltenango Department'},
                 {'dcid': 'wikidataId/Q883734',
                  'name': 'Suchitepéquez Department'},
                 {'dcid': 'wikidataId/Q883907',
                  'name': 'San Marcos Department'},
                 {'dcid': 'wikidataId/Q885644',
                  'name': 'Totonicapán Department'},
                 {'dcid': 'wikidataId/Q885656',
                  'name': 'Santa Rosa Department'},
                 {'dcid': 'wikidataId/Q888307',
                  'name': 'Retalhuleu Department'}]}
```

**Example 4** Get all countries contained in Earth. This returns 256 entities.

```python
dc = DataCommonsClient(dc_instance="datacommons.one.org")

children = dc.node.fetch_place_descendants("Earth", descendants_type="Country")
```
**Example 4** Get all AdministrativeArea 1 children of africa. This returns 921 entities.
```python
dc = DataCommonsClient(dc_instance="datacommons.one.org")

children = dc.node.fetch_place_children("africa", children_type="AdministrativeArea1")
```

Doing a similar search but via `fetch_entity_descendants` yields 7862 entities, since it gets all AdministrativeArea1 entities that in some way share africa in their ancestry.

```python
dc = DataCommonsClient(dc_instance="datacommons.one.org")

descendants = dc.node.fetch_place_descendants("africa", descendants_type="AdministrativeArea2")

```