### PR TITLE
[Fix] Handle empty/malformed REST API node responses

### DIFF
--- a/datacommons_client/utils/data_processing.py
+++ b/datacommons_client/utils/data_processing.py
@@ -48,7 +48,8 @@ def flatten_properties(
     properties = getattr(node_data, "properties", None)
 
     processed_arcs = unpack_arcs(arcs) if arcs else None
-    items[node] = processed_arcs if processed_arcs is not None else properties
+    if properties or processed_arcs:
+      items[node] = processed_arcs if processed_arcs is not None else properties
 
   return items
 


### PR DESCRIPTION
TL;DR: the REST API can return valid but malformed responses with empty data. This small fix defends against that when flattening the response.

Thanks @kmoscoe for spotting this!

---
A typical node response looks as follows:

```json
{
  "data": {
    "geoId/15009991200": {
      "arcs": {
        "containedInPlace": {
          "nodes": [
            {
              "dcid": "geoId/150099912000",
              "name": "Block Group 0, Census Tract 9912, Maui County, Hawaii",
              "provenanceId": "dc/base/BaseGeos",
              "types": [
                "CensusBlockGroup"
              ]
            }
          ]
        }
      }
    }
  }
}
```

However, for some *obscure* nodes, the response unexpectedly structured as:

```json
{
  "data": {
    "dc/2d5th8wq69trh": {}
  }
}
```

This is a REST API issue. I will submit a bug about it.

This PR makes sure that when extracting properties we can deal with this type of empty response.

