### PR TITLE
Use string literal type hints for pd.DataFrame.

### DIFF
--- a/datacommons_client/utils/dataframes.py
+++ b/datacommons_client/utils/dataframes.py
@@ -12,9 +12,9 @@ from datacommons_client.utils.decorators import requires_pandas
 @requires_pandas
 def add_entity_names_to_observations_dataframe(
     endpoint: NodeEndpoint,
-    observations_df: pd.DataFrame,
+    observations_df: "pd.DataFrame",  # type: ignore[reportInvalidTypeForm]
     entity_columns: str | list[str],
-) -> pd.DataFrame:
+) -> "pd.DataFrame":  # type: ignore[reportInvalidTypeForm]
   """
     Adds entity names to the observations DataFrame.
 


### PR DESCRIPTION
Using pd.DataFrame as a type hint causes a `AttributeError: 'NoneType' object has no attribute 'DataFrame'` exception when pandas is not installed because pd.Dataframe evaluates to None.DataFrame.

The comments `# type: ignore[reportInvalidTypeForm]` is to ignore VSCode Pylance warning of "Variable not allowed in type expression [Pylance(reportInvalidTypeForm)]" since pd is instantiated as a variable when pandas is not installed. 

Testing Approach:
1. (Before) From the the root of the repo in a python env _without pandas installed,_ I ran:
```
python3 -m pip install .
python3 datacommons_client/utils/dataframes.py
```
This raised:
```
Traceback (most recent call last):
  File "/Users/calinc/api-python/datacommons_client/utils/dataframes.py", line 1, in <module>
    from datacommons_client.endpoints.node import NodeEndpoint
  File "/Users/calinc/api-python/test_env/lib/python3.12/site-packages/datacommons_client/__init__.py", line 8, in <module>
    from datacommons_client.client import DataCommonsClient
  File "/Users/calinc/api-python/test_env/lib/python3.12/site-packages/datacommons_client/client.py", line 8, in <module>
    from datacommons_client.utils.dataframes import add_entity_names_to_observations_dataframe
  File "/Users/calinc/api-python/test_env/lib/python3.12/site-packages/datacommons_client/utils/dataframes.py", line 15, in <module>
    observations_df: pd.DataFrame,
                     ^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'DataFrame'
```

2. Ran 
```
python3 -m pip uninstall datacommons_client
```
to delete this original version of the module from my env.

3. (After) Made the change and reran
```
python3 -m pip install .
python3 datacommons_client/utils/dataframes.py
```
which no longer raised any errors.

@jm-rivera fyi :)