### PR TITLE
Release new versions of legacy python client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,5 @@
 # Changelog
 
-## 1.4.4
-
-**Date** - 01/12/2026
-
-**Release Tag** - [py1.4.4](https://github.com/datacommonsorg/api-python/releases/tag/py1.4.4)
-
-**Release Status** - Current head of branch [`master`](https://github.com/datacommonsorg/api-python/tree/master)
-
-Added deprecation notice to legacy `datacommons` package.
-
 ## 2.1.5
 
 **Date** - 01/12/2026
@@ -97,6 +87,16 @@ New features:
 **Release Status** - Current head of branch [`master`](https://github.com/datacommonsorg/api-python/tree/master)
 
 Initial v2 of the Data Commons API Python client library.
+
+## 1.4.4
+
+**Date** - 01/12/2026
+
+**Release Tag** - [py1.4.4](https://github.com/datacommonsorg/api-python/releases/tag/py1.4.4)
+
+**Release Status** - Current head of branch [`master`](https://github.com/datacommonsorg/api-python/tree/master)
+
+Added deprecation notice to legacy `datacommons` package.
 
 ## 1.4.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.4.4
+
+**Date** - 01/12/2026
+
+**Release Tag** - [py1.4.4](https://github.com/datacommonsorg/api-python/releases/tag/py1.4.4)
+
+**Release Status** - Current head of branch [`master`](https://github.com/datacommonsorg/api-python/tree/master)
+
+Added deprecation notice to legacy `datacommons` package.
+
 ## 2.1.5
 
 **Date** - 01/12/2026

--- a/datacommons_pandas/CHANGELOG.md
+++ b/datacommons_pandas/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.0.4
+
+**Date** - 01/12/2026
+
+**Release Tag** - [pd.0.0.4](https://github.com/datacommonsorg/api-python/releases/tag/pd0.0.4)
+
+**Release Status** - Current head of branch [`master`](https://github.com/datacommonsorg/api-python/tree/master)
+
+Added deprecation notice to legacy `datacommons_pandas` package.
+
 ## 0.0.3
 
 **Date** - 11/10/2020


### PR DESCRIPTION
Includes deprecation notice added in https://github.com/datacommonsorg/api-python/pull/285

New versions available at:
* https://pypi.org/project/datacommons/1.4.4/
* https://pypi.org/project/datacommons-pandas/0.0.4/