### PR TITLE
Add support for resolving indicators

### DIFF
--- a/datacommons_client/endpoints/payloads.py
+++ b/datacommons_client/endpoints/payloads.py
@@ -133,4 +133,7 @@ class ResolveRequestPayload(BaseDCModel):
     """
 
   node_dcids: ListOrStr = Field(..., serialization_alias="nodes")
-  expression: str | list[str] = Field(..., serialization_alias="property")
+  expression: str | list[str] | None = Field(default=None,
+                                             serialization_alias="property")
+  resolver: str | None = Field(default=None, serialization_alias="resolver")
+  target: str | None = Field(default=None, serialization_alias="target")

--- a/datacommons_client/endpoints/resolve.py
+++ b/datacommons_client/endpoints/resolve.py
@@ -37,8 +37,11 @@ class ResolveEndpoint(Endpoint):
     """Initializes the ResolveEndpoint instance."""
     super().__init__(endpoint="resolve", api=api)
 
-  def fetch(self, node_ids: str | list[str],
-            expression: str | list[str]) -> ResolveResponse:
+  def fetch(self,
+            node_ids: str | list[str],
+            expression: str | list[str] | None = None,
+            resolver: str | None = None,
+            target: str | None = None) -> ResolveResponse:
     """
         Fetches resolved data for the given nodes and expressions, identified by name,
          coordinates, or wiki ID.
@@ -46,6 +49,8 @@ class ResolveEndpoint(Endpoint):
         Args:
             node_ids (str | list[str]): One or more node IDs to resolve.
             expression (str): The relation expression to query.
+            resolver (str | None): The resolver type to use (e.g., "indicator").
+            target (str | None): The resolution target (e.g., "custom_only").
 
         Returns:
             ResolveResponse: The response object containing the resolved data.
@@ -56,10 +61,27 @@ class ResolveEndpoint(Endpoint):
 
     # Construct the payload
     payload = ResolveRequestPayload(node_dcids=node_ids,
-                                    expression=expression).to_dict()
+                                    expression=expression,
+                                    resolver=resolver,
+                                    target=target).to_dict()
 
     # Send the request and return the response
     return ResolveResponse.model_validate(self.post(payload))
+
+  def fetch_indicators(self,
+                       queries: str | list[str],
+                       target: str | None = None) -> ResolveResponse:
+    """
+      Fetches resolved indicators (StatisticalVariables or Topics) for the given queries.
+
+      Args:
+          queries (str | list[str]): One or more queries (e.g. "population", "gdp").
+          target (str | None): Optional target for resolution (e.g., "base_only", "custom_only", "base_and_custom").
+
+      Returns:
+          ResolveResponse: The response object containing the resolved indicators.
+      """
+    return self.fetch(node_ids=queries, resolver="indicator", target=target)
 
   def fetch_dcids_by_name(self,
                           names: str | list[str],

--- a/datacommons_client/models/resolve.py
+++ b/datacommons_client/models/resolve.py
@@ -20,6 +20,8 @@ class Candidate(BaseDCModel):
 
   dcid: NodeDCID = Field(default_factory=str)
   dominantType: Optional[DominantType] = None
+  metadata: dict[str, str] | None = None
+  typeOf: list[str] | None = None
 
 
 class Entity(BaseDCModel):

--- a/datacommons_client/tests/endpoints/test_resolve_endpoint.py
+++ b/datacommons_client/tests/endpoints/test_resolve_endpoint.py
@@ -163,7 +163,8 @@ def test_fetch_indicators_calls_endpoints_correctly():
   # Mock response data structure
   mock_response_data = {
       "entities": [{
-          "node": "population",
+          "node":
+              "population",
           "candidates": [{
               "dcid": "Count_Person",
               "dominantType": "StatisticalVariable",

--- a/datacommons_client/tests/endpoints/test_response.py
+++ b/datacommons_client/tests/endpoints/test_response.py
@@ -856,11 +856,15 @@ def test_resolve_response_dict():
               "candidates": [
                   {
                       "dcid": "dcid1",
-                      "dominantType": "Type1"
+                      "dominantType": "Type1",
+                      "metadata": None,
+                      "typeOf": None,
                   },
                   {
                       "dcid": "dcid2",
-                      "dominantType": None
+                      "dominantType": None,
+                      "metadata": None,
+                      "typeOf": None,
                   },
               ],
           },
@@ -868,7 +872,9 @@ def test_resolve_response_dict():
               "node": "entity2",
               "candidates": [{
                   "dcid": "dcid3",
-                  "dominantType": "Type2"
+                  "dominantType": "Type2",
+                  "metadata": None,
+                  "typeOf": None,
               },],
           },
       ]
@@ -968,11 +974,15 @@ def test_resolve_response_json_string_exclude_none():
               "candidates": [
                   {
                       "dcid": "dcid1",
-                      "dominantType": "Type1"
+                      "dominantType": "Type1",
+                      "metadata": None,
+                      "typeOf": None,
                   },
                   {
                       "dcid": "dcid2",
-                      "dominantType": None
+                      "dominantType": None,
+                      "metadata": None,
+                      "typeOf": None,
                   },
               ],
           },
@@ -980,7 +990,9 @@ def test_resolve_response_json_string_exclude_none():
               "node": "entity2",
               "candidates": [{
                   "dcid": "dcid3",
-                  "dominantType": "Type2"
+                  "dominantType": "Type2",
+                  "metadata": None,
+                  "typeOf": None,
               },],
           },
           {

--- a/datacommons_client/tests/endpoints/test_response.py
+++ b/datacommons_client/tests/endpoints/test_response.py
@@ -869,7 +869,8 @@ def test_resolve_response_dict():
               ],
           },
           {
-              "node": "entity2",
+              "node":
+                  "entity2",
               "candidates": [{
                   "dcid": "dcid3",
                   "dominantType": "Type2",
@@ -987,7 +988,8 @@ def test_resolve_response_json_string_exclude_none():
               ],
           },
           {
-              "node": "entity2",
+              "node":
+                  "entity2",
               "candidates": [{
                   "dcid": "dcid3",
                   "dominantType": "Type2",


### PR DESCRIPTION
* Added support for resolving NL queries to indicators (variables and topics)
* Updated `resolve` endpoint to support `resolver` and `target` arguments
* Added `fetch_indicators` convenience method
* Added match scores and entity types in response candidates
* Added unit tests and also did manual verification against custom dc on dc-dev with [this script](https://paste.googleplex.com/5183375088418816)